### PR TITLE
Plex split bugfix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-prosper-api (1.2.0.dev1) stable; urgency=low
+prosper-api (1.2.0) stable; urgency=low
 
   * Adding split coverage ahead of PLEX split
   * Converting CCP source to ESI by default
-  * More bugfixes for split_utils
+  * Improving compatability with Intel Python Tools
+  * Moving prod logs to `/var/logs/prosper`
 
  -- John Purcell <jpurcell.ee@gmail.com>  Mon, 08 May 2017 20:00:00 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
-prosper-api (1.2.0.dev0) stable; urgency=low
+prosper-api (1.2.0.dev1) stable; urgency=low
 
   * Adding split coverage ahead of PLEX split
   * Converting CCP source to ESI by default
+  * More bugfixes for split_utils
 
  -- John Purcell <jpurcell.ee@gmail.com>  Mon, 08 May 2017 20:00:00 -0700
 

--- a/publicAPI/crest_endpoint.py
+++ b/publicAPI/crest_endpoint.py
@@ -327,6 +327,11 @@ class ProphetEndpoint(Resource):
                     config=api_config.CONFIG,
                     logger=LOGGER
                 )
+                data.sort_values(
+                    by='date',
+                    ascending=True,
+                    inplace=True
+                )
             else:
                 data = forecast_utils.fetch_extended_history(
                     args.get('regionID'),

--- a/publicAPI/split_info.json
+++ b/publicAPI/split_info.json
@@ -5,7 +5,7 @@
 		"original_id":29668,
 		"new_id":44992,
 		"split_date":"2017-05-09",
-		"bool_mult_div":"False",
+		"bool_mult_div":"True",
 		"split_rate":500
 	},
 	{
@@ -14,7 +14,7 @@
 		"original_id":29668,
 		"new_id":44992,
 		"split_date":"2017-05-09",
-		"bool_mult_div":"True",
+		"bool_mult_div":"False",
 		"split_rate":500
 	}
 ]

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -264,8 +264,7 @@ def execute_split(
         split_dataframe,
         split_obj,
         price_keys=PRICE_KEYS,
-        volume_keys=VOLUME_KEYS,
-        logger=api_config.LOGGER
+        volume_keys=VOLUME_KEYS
 ):
     """apply split to dataframe
 
@@ -371,8 +370,7 @@ def fetch_split_history(
         logger.info('--splitting old-data')
         split_data = execute_split(
             split_data,
-            split_obj,
-            logger=logger
+            split_obj
         )
     # vv FIX ME vv: Testable? #
     elif type_id == split_obj.original_id: #adjust the current data

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -323,6 +323,7 @@ def fetch_split_history(
     split_obj = api_config.SPLIT_INFO[type_id]
     fetch_id = split_obj.current_typeid()
 
+    logger.debug(split_obj.__dict__)
     logger.info(
         'fetching data from remote {0} (was {1})'.\
         format(type_id, fetch_id)
@@ -365,15 +366,7 @@ def fetch_split_history(
         split_obj.original_id,
         split_date=split_obj.date_str
     )
-    split_data.to_csv(
-        path.join(HERE, 'split_data_{0}.csv'.format(type_id)),
-        index=False
-    )
-    current_data.to_csv(
-        path.join(HERE, 'current_data_{0}.csv'.format(type_id)),
-        index=False
-    )
-    logger.info(split_obj.__dict__)
+
     if type_id == split_obj.new_id: #adjust the back history
         logger.info('--splitting old-data')
         split_data = execute_split(

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -356,6 +356,14 @@ def fetch_split_history(
         split_obj.original_id,
         split_date=split_obj.date_str
     )
+    split_data.to_csv(
+        path.join(HERE, 'split_data_{0}.csv'.format(type_id)),
+        index=False
+    )
+    current_data.to_csv(
+        path.join(HERE, 'current_data_{0}.csv'.format(type_id)),
+        index=False
+    )
     if type_id == split_obj.new_id: #adjust the back history
         logger.info('--splitting old-data')
         split_data = execute_split(


### PR DESCRIPTION
* Reversed `bool_mult_div` for plex/newplex
* Forced `to_numeric()` when applying split adjustment
* Removed debug `to_csv()`
* Fixed sorting for Prophet raw data (date ASC)
* Updating changelog to reflect all 1.2.0 features

Fixes: #2 
