### PR TITLE
v1.2 Deprecate CREST and fix tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[report]
+    omit = 
+        publicAPI/__init__.py
+        publicAPI/_version.py
+        publicAPI/config.py
+        publicAPI/exceptions.py
+
+[paths]
+    source = publicAPI

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 branches:
   only:
   - master
-  - travis_test
+  - v1.2_withsplit
 after_success:
   - "pip install python-coveralls"
   - "coveralls"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+prosper-api (1.3.0) stable; urgency=low
+
+  * Fixes serious test errors
+  * Updates requirements from static to latest
+  * Upgrades pystan to 2.15.0
+  * Upgrades fbprophet to 0.3.post1
+  * Deprecates CREST functionality
+  * Improves logging patterns
+  * Improves coverage patterns
+  * Updates helper scripts
+
+ -- John Purcell <jpurcell.ee@gmail.com>  Mon, 11 Jun 2018 10:00:00 -0700
+
 prosper-api (1.2.2) stable; urgency=low
 
   * upgrading project for ProsperCommon v1.1.0

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 
 ifneq ($(wildcard /opt/intel/intelpython3/.*),)	#use intelpython bindings if available
 override_dh_virtualenv:
-	dh_virtualenv --python /opt/intel/intelpython3/bin/python3.5 --preinstall cython==0.24 --preinstall numpy==1.11.1 --preinstall matplotlib --use-system-packages
+	dh_virtualenv --python /opt/intel/intelpython3/bin/python3.5 --preinstall cython --preinstall numpy --preinstall matplotlib --use-system-packages
 else
 override_dh_virtualenv:
 	dh_virtualenv --python /usr/bin/python3.5 --preinstall cython --preinstall numpy --preinstall matplotlib

--- a/publicAPI/__init__.py
+++ b/publicAPI/__init__.py
@@ -40,7 +40,7 @@ def create_app(
 
     log_builder = p_logging.ProsperLogger(
         'publicAPI',
-        local_configs['LOGGING']['log_path'],
+        local_configs.get_option('LOGGING', 'log_path'),
         local_configs
     )
     if app.debug or testmode:

--- a/publicAPI/__init__.py
+++ b/publicAPI/__init__.py
@@ -3,23 +3,12 @@ from os import path
 import warnings
 import logging
 
-try:
-    from flask import Flask
-
-    import publicAPI.crest_endpoint as crest_endpoint
-    import publicAPI.config as config
-    import publicAPI.split_utils as split_utils
-
-    import prosper.common.prosper_logging as p_logging
-except ImportError:
-    warnings.warn('pre-install mode -- requirements not installed', UserWarning)
-
 HERE = path.abspath(path.dirname(__file__))
 
 def create_app(
         settings=None,
         local_configs=None,
-        testmode=False
+        testmode=False,
 ):
     """create Flask application (ROOT)
 
@@ -28,9 +17,17 @@ def create_app(
     Args:
         settings (:obj:`dict`, optional): collection of Flask options
         local_configs (:obj:`configparser.ConfigParser` optional): app private configs
-        log_builder (:obj:`prosper_config.ProsperLogger`, optional): logging container
+        testmode (bool): pytest hook
 
     """
+    from flask import Flask
+
+    import publicAPI.crest_endpoint as crest_endpoint
+    import publicAPI.config as config
+    import publicAPI.split_utils as split_utils
+
+    import prosper.common.prosper_logging as p_logging
+
     app = Flask(__name__)
 
     if settings:

--- a/publicAPI/__init__.py
+++ b/publicAPI/__init__.py
@@ -40,7 +40,7 @@ def create_app(
 
     log_builder = p_logging.ProsperLogger(
         'publicAPI',
-        '/var/log/prosper/',
+        local_configs['LOGGING']['log_path'],
         local_configs
     )
     if app.debug or testmode:

--- a/publicAPI/api_utils.py
+++ b/publicAPI/api_utils.py
@@ -1,5 +1,6 @@
 from os import path, makedirs
 from datetime import datetime
+import logging
 
 import ujson as json
 from tinymongo import TinyMongoClient
@@ -7,7 +8,7 @@ from tinymongo import TinyMongoClient
 import prosper.common.prosper_logging as p_logging
 import publicAPI.exceptions as exceptions
 
-LOGGER = p_logging.DEFAULT_LOGGER
+LOGGER = logging.getLogger('publicAPI')
 HERE = path.abspath(path.dirname(__file__))
 
 CACHE_PATH = path.join(HERE, 'cache')
@@ -16,7 +17,7 @@ makedirs(CACHE_PATH, exist_ok=True)
 def check_key(
         api_key,
         throw_on_fail=False,
-        logger=LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """check if API key is valid
 

--- a/publicAPI/api_utils.py
+++ b/publicAPI/api_utils.py
@@ -29,7 +29,7 @@ def check_key(
         logger (:obj:`logging.logger`): logging handle
 
     Returns:
-        (bool) access allowed or not
+        bool: access allowed or not
 
     """
 

--- a/publicAPI/config.py
+++ b/publicAPI/config.py
@@ -1,13 +1,14 @@
 """config.py: a place to hold config/globals"""
 from os import path
 from enum import Enum
+import logging
 
 import prosper.common.prosper_logging as p_logging
 import prosper.common.prosper_config as p_config
 
 HERE = path.abspath(path.dirname(__file__))
 
-LOGGER = p_logging.DEFAULT_LOGGER
+LOGGER =logging.getLogger('publicAPI')
 CONFIG = None #TODO
 
 USER_AGENT = 'lockefox https://github.com/EVEprosper/ProsperAPI'

--- a/publicAPI/crest_endpoint.py
+++ b/publicAPI/crest_endpoint.py
@@ -4,6 +4,7 @@ import sys
 from os import path
 from datetime import datetime
 from enum import Enum
+import logging
 
 import ujson as json
 from flask import Flask, Response, jsonify
@@ -85,44 +86,38 @@ class OHLC_endpoint(Resource):
             help='API key for tracking requests',
             location=['args', 'headers']
         )
-
+        self.logger = logging.getLogger('publicAPI')
     def get(self, return_type):
         """GET data from CREST and send out OHLC info"""
         args = self.reqparse.parse_args()
         #TODO: info archive
-        LOGGER.info('OHLC {0} Request: {1}'.format(return_type, args))
+        self.logger.info('OHLC %s Request: %s', return_type, args)
 
         if return_type not in return_supported_types():
             return 'INVALID RETURN FORMAT', 405
-
-        mode = api_config.SwitchCCPSource(
-            api_config.CONFIG.get('GLOBAL', 'crest_or_esi')
-        )
         ## Validate inputs ##
         try:
             crest_utils.validate_id(
                 'map_regions',
                 args.get('regionID'),
-                mode=mode,
                 config=api_config.CONFIG,
-                logger=LOGGER
+                logger=self.logger,
             )
             crest_utils.validate_id(
                 'inventory_types',
                 args.get('typeID'),
-                mode=mode,
                 config=api_config.CONFIG,
-                logger=LOGGER
+                logger=self.logger,
             )
         except exceptions.ValidatorException as err:
-            LOGGER.warning(
+            self.logger.warning(
                 'ERROR: unable to validate type/region ids' +
                 '\n\targs={0}'.format(args),
                 exc_info=True
             )
             return err.message, err.status
         except Exception: #pragma: no cover
-            LOGGER.error(
+            self.logger.error(
                 'ERROR: unable to validate type/region ids' +
                 'args={0}'.format(args),
                 exc_info=True
@@ -133,49 +128,46 @@ class OHLC_endpoint(Resource):
         try:
             #LOGGER.info(api_config.SPLIT_INFO)
             if args.get('typeID') in api_config.SPLIT_INFO:
-                LOGGER.info('FORK: using split utility')
+                self.logger.info('FORK: using split utility')
                 data = split_utils.fetch_split_history(
                     args.get('regionID'),
                     args.get('typeID'),
-                    mode,
                     config=api_config.CONFIG,
-                    logger=LOGGER
+                    logger=self.logger,
                 )
             else:
                 data = crest_utils.fetch_market_history(
                     args.get('regionID'),
                     args.get('typeID'),
                     config=api_config.CONFIG,
-                    mode=mode,
                     logger=LOGGER
                 )
             data = crest_utils.data_to_ohlc(data)
         except exceptions.ValidatorException as err: #pragma: no cover
-            LOGGER.error(
-                'ERROR: unable to parse CREST data' +
-                '\n\targs={0}'.format(args),
+            self.logger.error(
+                'ERROR: unable to parse CREST data\n\targs=%s',
+                args,
                 exc_info=True
             )
             return err.message, err.status
         except Exception: #pragma: no cover
-        #except Exception as err:    #pragma: no cover
-            LOGGER.error(
-                'ERROR: unhandled issue in parsing CREST data' +
-                'args={0}'.format(args),
+            self.logger.error(
+                'ERROR: unhandled issue in parsing CREST data\n\targs=%s',
+                args,
                 exc_info=True
             )
             return 'UNHANDLED EXCEPTION', 500
 
         ## Format output ##
         if return_type == AcceptedDataFormat.JSON.value:
-            LOGGER.info('rolling json response')
+            self.logger.info('rolling json response')
             data_str = data.to_json(
                 path_or_buf=None,
                 orient='records'
             )
             message = json.loads(data_str)
         elif return_type == AcceptedDataFormat.CSV.value:
-            LOGGER.info('rolling csv response')
+            self.logger.info('rolling csv response')
             data_str = data.to_csv(
                 path_or_buf=None,
                 header=True,
@@ -192,10 +184,11 @@ class OHLC_endpoint(Resource):
             message = output_csv(data_str, 200)
         else:   #pragma: no cover
             #TODO: CUT?
-            LOGGER.error(
+            self.logger.error(
                 'invalid format requested' +
-                '\n\targs={0}'.format(args) +
-                '\n\treturn_type={0}'.format(return_type),
+                '\n\targs=%s' +
+                '\n\treturn_type=%s',
+                args, return_type,
                 exc_info=True
             )
             return 'UNSUPPORTED FORMAT', 500
@@ -242,18 +235,14 @@ class ProphetEndpoint(Resource):
                 format(api_config.DEFAULT_RANGE, api_config.MAX_RANGE),
             location=['args', 'headers']
         )
-
+        self.logger = logging.getLogger('publicAPI')
     def get(self, return_type):
         args = self.reqparse.parse_args()
-        LOGGER.info('Prophet {0} Request: {1}'.format(return_type, args))
-
+        self.logger.info('Prophet %s Request: %s', return_type, args)
 
         if return_type not in return_supported_types():
             return 'INVALID RETURN FORMAT', 405
 
-        mode = api_config.SwitchCCPSource(
-            api_config.CONFIG.get('GLOBAL', 'crest_or_esi')
-        )
         forecast_range = api_config.DEFAULT_RANGE
         if 'range' in args:
             forecast_range = args.get('range')
@@ -262,21 +251,19 @@ class ProphetEndpoint(Resource):
             api_utils.check_key(
                 args.get('api'),
                 throw_on_fail=True,
-                logger=LOGGER
+                logger=self.logger,
             )
             crest_utils.validate_id(
                 'map_regions',
                 args.get('regionID'),
                 config=api_config.CONFIG,
-                mode=mode,
-                logger=LOGGER
+                logger=self.logger,
             )
             crest_utils.validate_id(
                 'inventory_types',
                 args.get('typeID'),
                 config=api_config.CONFIG,
-                mode=mode,
-                logger=LOGGER
+                logger=self.logger,
             )
             forecast_range = forecast_utils.check_requested_range(
                 forecast_range,
@@ -284,16 +271,16 @@ class ProphetEndpoint(Resource):
                 raise_for_status=True
             )
         except exceptions.ValidatorException as err:
-            LOGGER.warning(
-                'ERROR: unable to validate type/region ids' +
-                '\n\targs={0}'.format(args),
+            self.logger.warning(
+                'ERROR: unable to validate type/region ids\n\targs=%s',
+                args,
                 exc_info=True
             )
             return err.message, err.status
         except Exception: #pragma: no cover
-            LOGGER.error(
-                'ERROR: unable to validate type/region ids' +
-                'args={0}'.format(args),
+            self.logger.error(
+                'ERROR: unable to validate type/region ids\n\targs=%s',
+                args,
                 exc_info=True
             )
             return 'UNHANDLED EXCEPTION', 500
@@ -310,7 +297,7 @@ class ProphetEndpoint(Resource):
                 cache_data,
                 forecast_range,
                 return_type,
-                LOGGER
+                self.logger,
             )
 
             return message
@@ -322,10 +309,9 @@ class ProphetEndpoint(Resource):
                 data = split_utils.fetch_split_history(
                     args.get('regionID'),
                     args.get('typeID'),
-                    mode,
                     data_range=api_config.MAX_RANGE,
                     config=api_config.CONFIG,
-                    logger=LOGGER
+                    logger=self.logger,
                 )
                 data.sort_values(
                     by='date',
@@ -336,10 +322,9 @@ class ProphetEndpoint(Resource):
                 data = forecast_utils.fetch_extended_history(
                     args.get('regionID'),
                     args.get('typeID'),
-                    mode=mode,
                     data_range=api_config.MAX_RANGE,
                     config=api_config.CONFIG,
-                    logger=LOGGER
+                    logger=self.logger,
                 )
             data = forecast_utils.build_forecast(
                 data,
@@ -347,16 +332,16 @@ class ProphetEndpoint(Resource):
             )
         except exceptions.ValidatorException as err:
             #FIX ME: testing?
-            LOGGER.warning(
-                'ERROR: unable to generate forecast' +
-                '\n\targs={0}'.format(args),
+            self.logger.warning(
+                'ERROR: unable to generate forecast\n\targs=%s',
+                args,
                 exc_info=True
             )
             return err.message, err.status
         except Exception: #pragma: no cover
             LOGGER.error(
-                'ERROR: unable to generate forecast' +
-                '\n\targs={0}'.format(args),
+                'ERROR: unable to generate forecast\n\targs=%s',
+                args,
                 exc_info=True
             )
             return 'UNHANDLED EXCEPTION', 500
@@ -366,20 +351,21 @@ class ProphetEndpoint(Resource):
             args.get('regionID'),
             args.get('typeID'),
             data,
-            logger=LOGGER
+            logger=self.logger,
         )
         try:
             message = forecast_reporter(
                 data,
                 forecast_range,
                 return_type,
-                LOGGER
+                self.logger,
             )
         except Exception as err_msg:    #pragma: no cover
             LOGGER.error(
-                'invalid format requested' +
-                '\n\targs={0}'.format(args) +
-                '\n\treturn_type={0}'.format(return_type),
+                'invalid format requested'
+                '\n\targs=%s'
+                '\n\treturn_type=%s',
+                args, return_type,
                 exc_info=True
             )
             return 'UNABLE TO GENERATE REPORT', 500
@@ -389,7 +375,7 @@ def forecast_reporter(
         data,
         forecast_range,
         return_type,
-        logger=LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """prepares forecast response for Flask
 

--- a/publicAPI/crest_endpoint.py
+++ b/publicAPI/crest_endpoint.py
@@ -290,9 +290,9 @@ class ProphetEndpoint(Resource):
             args.get('regionID'),
             args.get('typeID')
         )
-        LOGGER.debug(cache_data)
+        self.logger.debug(cache_data)
         if cache_data is not None:
-            LOGGER.info('returning cached forecast')
+            self.logger.info('returning cached forecast')
             message = forecast_reporter(
                 cache_data,
                 forecast_range,

--- a/publicAPI/crest_utils.py
+++ b/publicAPI/crest_utils.py
@@ -2,11 +2,12 @@
 
 from os import path, makedirs
 from datetime import datetime
-from retrying import retry
-import pytz
 import configparser
+import logging
+import warnings
 
 import ujson as json
+from retrying import retry
 import requests
 from tinydb import TinyDB, Query
 import pandas as pd
@@ -18,7 +19,7 @@ import publicAPI.exceptions as exceptions
 import publicAPI.config as api_config
 import prosper.common.prosper_logging as p_logging
 
-LOGGER = p_logging.DEFAULT_LOGGER
+LOGGER = logging.getLogger('publicAPI')
 HERE = path.abspath(path.dirname(__file__))
 
 CACHE_PATH = path.join(HERE, 'cache')
@@ -109,10 +110,10 @@ def endpoint_to_kwarg(
 def validate_id(
         endpoint_name,
         type_id,
-        mode=api_config.SwitchCCPSource.CREST,
+        mode=api_config.SwitchCCPSource.ESI,
         cache_buster=False,
         config=api_config.CONFIG,
-        logger=LOGGER
+        logger=logging.getLogger('publicAPI'),
 ):
     """Check EVE Online CREST as source-of-truth for id lookup
 
@@ -165,6 +166,7 @@ def validate_id(
         )
         type_info = None
         if mode == api_config.SwitchCCPSource.CREST:
+            warnings.warn('CREST service deprecated by CCP, use ESI', DeprecationWarning)
             type_info = fetch_crest_endpoint(
                 endpoint_name,
                 **kwarg_pair,
@@ -233,6 +235,7 @@ def fetch_crest_endpoint(
         (:obj:`dict`): JSON object returned by endpoint
 
     """
+    warnings.warn('CREST service deprecated by CCP, use ESI', DeprecationWarning)
     try:
         crest_url = crest_base + config.get('RESOURCES', endpoint_name)
     except (configparser.NoOptionError, KeyError):

--- a/publicAPI/crest_utils.py
+++ b/publicAPI/crest_utils.py
@@ -34,10 +34,9 @@ def setup_cache_file(
     Args:
         cache_filename (str): path to desired cache file
         cache_path (str, optional): path to cache folder
-        logger (:obj:`logging.logger`, optional): logging handle
 
     Returns:
-        (:obj:`TinyDB.TinyDB`): cache db
+        TinyDB.TinyDB: cache db
 
     """
     if not path.isdir(CACHE_PATH):
@@ -92,7 +91,7 @@ def endpoint_to_kwarg(
         type_id (int): EVE Online ID
 
     Returns:
-        (:obj:`dict`) kwarg pair
+        dict: kwarg pair
 
     """
     kwarg_pair = {}
@@ -110,7 +109,6 @@ def endpoint_to_kwarg(
 def validate_id(
         endpoint_name,
         type_id,
-        # mode=api_config.SwitchCCPSource.ESI,
         cache_buster=False,
         config=api_config.CONFIG,
         logger=logging.getLogger('publicAPI'),
@@ -131,7 +129,7 @@ def validate_id(
     ## Check local cache for value ##
     try:
         db_handle = setup_cache_file(endpoint_name)
-    except Exception as err_msg:    #pragma: no cover
+    except Exception as err_msg:  # pragma: no cover
         logger.error(
             'ERROR: unable to connect to local tinyDB cache' +
             '\n\tendpoint_name: {0}'.format(endpoint_name) +
@@ -194,7 +192,7 @@ def validate_id(
             type_id,
             type_info
         )
-    except Exception as err_msg:    #pragma: no cover
+    except Exception as err_msg:  # pragma: no cover
         logger.error(
             'ERROR: unable to write to cache' +
             '\n\ttype_id: {0}'.format(type_id) +
@@ -221,7 +219,7 @@ def fetch_crest_endpoint(
         **kwargs (:obj:`dict`): key/values to overwrite in query
 
     Returns:
-        (:obj:`dict`): JSON object returned by endpoint
+        dict: JSON object returned by endpoint
 
     """
     warnings.warn('CREST service deprecated by CCP, use ESI', DeprecationWarning)
@@ -315,7 +313,7 @@ def fetch_market_history(
         region_id,
         type_id,
         config=api_config.CONFIG,
-        logger=LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """Get market history data from EVE Online ESI endpoint
 
@@ -326,7 +324,7 @@ def fetch_market_history(
         logger (:obj:`logging.logger`): logging handle
 
     Returns:
-        pandas.data_frame: pandas collection of data
+        pandas.DataFrame: pandas collection of data
             ['date', 'avgPrice', 'highPrice', 'lowPrice', 'volume', 'orders']
     """
     logger.info('--fetching market data from ESI')
@@ -393,7 +391,7 @@ def data_to_ohlc(
         data (:obj:`pandas.DataFrame`): data to recast
 
     Returns:
-        (:obj:`pandas.DataFrame`): OHLC format
+        pandas.DataFrame: OHLC format
             ['date', 'open', 'high', 'low', 'close', 'volume']
 
     """

--- a/publicAPI/forecast_utils.py
+++ b/publicAPI/forecast_utils.py
@@ -17,7 +17,6 @@ import publicAPI.exceptions as exceptions
 import prosper.common.prosper_logging as p_logging
 
 HERE = path.abspath(path.dirname(__file__))
-#LOGGER = api_config.LOGGER
 
 CACHE_PATH = path.join(HERE, 'cache')
 makedirs(CACHE_PATH, exist_ok=True)
@@ -32,11 +31,11 @@ def check_prediction_cache(
     Args:
         region_id (int): EVE Online region ID
         type_id (int): EVE Online type ID
-        cache_path (str, optional): path to caches
-        db_filename (str, optional): name of tinydb
+        cache_path (str): path to caches
+        db_filename (str): name of tinydb
 
     Returns:
-        (:obj:`pandas.DataFrame`): cached prediction
+        pandas.DataFrame: cached prediction
 
     """
     utc_today = datetime.utcnow().strftime('%Y-%m-%d')
@@ -63,7 +62,7 @@ def write_prediction_cache(
         prediction_data,
         cache_path=CACHE_PATH,
         db_filename='prophet.json',
-        logger=api_config.LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """update tinydb latest prediction
 
@@ -120,11 +119,11 @@ def check_requested_range(
 
     Args:
         requested_range (int): number of days to forecast
-        max_range (int, optional): capped days (no more than this)
-        raise_for_status (bool, optional): raise exception if request too much
+        max_range (int): capped days (no more than this)
+        raise_for_status (bool): raise exception if request too much
 
     Returns:
-        (int): requested_range
+        int: requested_range
 
     """
 
@@ -147,19 +146,19 @@ def fetch_extended_history(
         crest_range=CREST_RANGE,
         config=api_config.CONFIG,
         data_range=DEFAULT_RANGE,
-        logger=api_config.LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """fetch data from database
 
     Args:
         region_id (int): EVE Online regionID: https://crest-tq.eveonline.com/regions/
         type_id (int): EVE Online typeID: https://crest-tq.eveonline.com/types/
-        cache_buster (bool, optional): skip cache, fetch new data
-        data_range (int, optional): how far back to fetch data
+        cache_buster (bool): skip cache, fetch new data
+        data_range (int): how far back to fetch data
         logger (:obj:`logging.logger`): logging handle
 
     Returns:
-        (:obj:`pandas.data_frame`): collection of data from database
+        pandas.DataFrame: collection of data from database
             ['date', 'avgPrice', 'highPrice', 'lowPrice', 'volume', 'orders']
     """
     logger.info('--fetching history data')
@@ -229,10 +228,9 @@ def trim_prediction(
         data (:obj:`pandas.DataFrame`): data reported
         history_days (int): number of days BACK to report
         prediction_days (int): number of days FORWARD to report
-        logger (:obj:`logging.logger`, optional): logging hooks for progress
 
     Returns:
-        (:obj:`pandas.DataFrame`): same shape as original dataframe, but with days removed
+        pandas.DataFrame: same shape as original dataframe, but with days removed
 
     """
     back_date = datetime.utcnow() - timedelta(days=history_days)
@@ -264,7 +262,7 @@ def fetch_market_history_emd(
         config (:obj:`configparser.ConfigParser`, optional): overrides for config
 
     Returns:
-        (:obj:`dict` json): collection of data from endpoint
+        dict: JSONable collection of data from endpoint
             ['typeID', 'regionID', 'date', 'lowPrice', 'highPrice', 'avgPrice', 'volume', 'orders']
 
     """
@@ -298,7 +296,7 @@ def parse_emd_data(data_result):
         data_result (:obj:`list`): data['result'] collection of row data
 
     Returns:
-        (:obj:`pandas.DataFrame`): processed row data in table form
+        pandas.DataFrame: processed row data in table form
 
     """
     clean_data = []
@@ -320,10 +318,9 @@ def build_forecast(
         data (:obj:`pandas.data_frame`): data to build prediction
         forecast_range (int): how much time into the future to forecast
         truncate_range (int, optional): truncate output to CREST_RANGE
-        logger (:obj:`logging.logger`, optional): logging handle
 
     Returns:
-        (:obj:`pandas.data_frame`): collection of data + forecast info
+        pandas.DataFrame: collection of data + forecast info
             ['date', 'avgPrice', 'yhat', 'yhat_low', 'yhat_high', 'prediction']
 
     """

--- a/publicAPI/forecast_utils.py
+++ b/publicAPI/forecast_utils.py
@@ -190,7 +190,6 @@ def fetch_extended_history(
                 region_id,
                 type_id,
                 config=config,
-                mode=mode,
                 logger=logger
             )
         except Exception as err_msg:    #pragma: no cover

--- a/publicAPI/forecast_utils.py
+++ b/publicAPI/forecast_utils.py
@@ -1,6 +1,7 @@
 """forecast_utils.py: collection of tools for forecasting future performance"""
 from os import path, makedirs
 from datetime import datetime, timedelta
+import logging
 
 import ujson as json
 import pandas as pd

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -159,13 +159,13 @@ def read_split_info(
 def datetime_helper(
         datetime_str
 ):
-    """try to conver datetime for comparison
+    """try to convert datetime for comparison
 
     Args:
         datetime_str (str): datetime str (%Y-%m-%d) or (%Y-%m-%dT%H:%M:S)
 
     Returns:
-        (:obj:`datetime.datetime`)
+        datetime.datetime
 
     """
     try:
@@ -185,7 +185,6 @@ def fetch_split_cache_data(
         region_id,
         type_id,
         split_date=None,
-        #split_cache_file=SPLIT_CACHE_FILE,
         keep_columns=KEEP_COLUMNS
 ):
     """get data from cache
@@ -193,10 +192,9 @@ def fetch_split_cache_data(
     Args:
         region_id (int): EVE Online region id
         type_id (int): EVE Online type id
-        split_cache_file (str, optional): path to split file
-
+        keep_colums (list): sort columns to keep in DataFrame
     Returns:
-        pandas.data_frame pandas collection of data
+        pandas.DataFrame: pandas collection of data
             ['date', 'avgPrice', 'highPrice', 'lowPrice', 'volume', 'orders']
 
     """
@@ -240,7 +238,7 @@ def combine_split_history(
         keep_columns (:obj:`list`, optional): expected headers/columns for dataframe
 
     Returns:
-        (:obj:`pandas.DataFrame`): combined data
+        pandas.DataFrame: combined data
 
     """
     current_data['date'] = pd.to_datetime(current_data['date']).dt.strftime('%Y-%m-%d')
@@ -277,7 +275,7 @@ def execute_split(
         volume_keys (:obj:`list`, optional): volume columns
 
     Returns:
-        (:obj:`pandas.DataFrame`): updated dataframe
+        pandas.DataFrame: updated dataframe
 
     """
     # vv FIXME vv: serial access to recast dataframe #
@@ -297,9 +295,8 @@ def fetch_split_history(
         type_id,
         fetch_source=api_config.SwitchCCPSource.EMD,
         data_range=400,
-        #split_cache_file=SPLIT_CACHE_FILE,
         config=api_config.CONFIG,
-        logger=api_config.LOGGER
+        logger=logging.getLogger('publicAPI')
 ):
     """for split items, fetch and stitch the data together
 
@@ -307,12 +304,12 @@ def fetch_split_history(
         region_id (int): EVE Online region_id
         type_id (int): EVE Online type_id
         fetch_source (:enum:`api_config.SwitchCCPSource`): which endpoint to fetch
-        data_range (int, optional): how much total data to fetch
-        config (:obj:`configparser.ConfigParser`, optional): config overrides
-        logger (:obj:`logging.logger`, optional): logging handle
+        data_range (int): how much total data to fetch
+        config (:obj:`configparser.ConfigParser`): config overrides
+        logger (:obj:`logging.logger`): logging handle
 
     Returns:
-        (:obj:`pandas.DataFrame`) data from endpoint
+        pandas.DataFrame: data from endpoint
 
     """
     ## Figure out if there's work to do ##
@@ -366,14 +363,14 @@ def fetch_split_history(
         split_date=split_obj.date_str
     )
 
-    if type_id == split_obj.new_id: #adjust the back history
+    if type_id == split_obj.new_id:  # adjust the back history
         logger.info('--splitting old-data')
         split_data = execute_split(
             split_data,
             split_obj
         )
     # vv FIX ME vv: Testable? #
-    elif type_id == split_obj.original_id: #adjust the current data
+    elif type_id == split_obj.original_id:  # adjust the current data
 
         logger.info('--splitting new-data')
         current_data = execute_split(
@@ -381,7 +378,7 @@ def fetch_split_history(
             split_obj
         )
     # ^^ FIX ME ^^ #
-    else:   #pragma: no cover
+    else:  # pragma: no cover
         logger.error(
             'Unable to map new/old type_ids correctly' +
             '\n\ttype_id={0}'.format(type_id) +
@@ -397,7 +394,7 @@ def fetch_split_history(
     current_data.to_csv('current_data.csv', index=False)
     split_data.to_csv('split_data.csv', index=False)
     combined_data = combine_split_history(
-        current_data.copy(),    #pass by value, not by reference
+        current_data.copy(),  # pass by value, not by reference
         split_data.copy()
     )
 

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -295,7 +295,7 @@ def execute_split(
 def fetch_split_history(
         region_id,
         type_id,
-        fetch_source=api_config.SwitchCCPSource.ESI,
+        fetch_source=api_config.SwitchCCPSource.EMD,
         data_range=400,
         #split_cache_file=SPLIT_CACHE_FILE,
         config=api_config.CONFIG,

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -2,6 +2,7 @@
 from os import path, makedirs
 from datetime import datetime
 import ast
+import logging
 
 import ujson as json
 import pandas as pd
@@ -127,7 +128,7 @@ class SplitInfo(object):
 
 def read_split_info(
         split_info_file=path.join(HERE, 'split_info.json'),
-        logger=api_config.LOGGER
+        logger=logging.getLogger('publicAPI'),
 ):
     """initialize SPLIT_INFO for project
 
@@ -135,7 +136,7 @@ def read_split_info(
         Does not update global SPLIT_INFO (use `main` scope)
 
     Args:
-         (str, optional): path to split_info.json
+        split_info_file (str, optional): path to split_info.json
         logger (:obj:`logging.logger`, optional): logging handle
 
     Returns:

--- a/publicAPI/split_utils.py
+++ b/publicAPI/split_utils.py
@@ -196,10 +196,11 @@ def fetch_split_cache_data(
         split_cache_file (str, optional): path to split file
 
     Returns:
-        (:obj:`pandas.data_frame`) pandas collection of data
+        pandas.data_frame pandas collection of data
             ['date', 'avgPrice', 'highPrice', 'lowPrice', 'volume', 'orders']
 
     """
+    print(api_config.SPLIT_CACHE_FILE)
     db_handle = TinyDB(api_config.SPLIT_CACHE_FILE)
 
     if split_date:
@@ -294,7 +295,7 @@ def execute_split(
 def fetch_split_history(
         region_id,
         type_id,
-        fetch_source,
+        fetch_source=api_config.SwitchCCPSource.ESI,
         data_range=400,
         #split_cache_file=SPLIT_CACHE_FILE,
         config=api_config.CONFIG,
@@ -325,8 +326,8 @@ def fetch_split_history(
 
     logger.debug(split_obj.__dict__)
     logger.info(
-        'fetching data from remote {0} (was {1})'.\
-        format(type_id, fetch_id)
+        'fetching data from remote %s (was %s)',
+        type_id, fetch_id
     )
     ## Get current market data ##
     if fetch_source == api_config.SwitchCCPSource.EMD:
@@ -336,7 +337,6 @@ def fetch_split_history(
             fetch_id,
             data_range=data_range,
             config=config,
-            #logger=logger
         )
         current_data = forecast_utils.parse_emd_data(current_data['result'])
     else:
@@ -344,7 +344,6 @@ def fetch_split_history(
         current_data = crest_utils.fetch_market_history(
             region_id,
             fetch_id,
-            mode=fetch_source,
             config=config,
             logger=logger
         )
@@ -358,9 +357,9 @@ def fetch_split_history(
 
     ## Fetch split data ##
     logger.info(
-        '--fetching data from cache {0}@{1}'.format(
-            split_obj.original_id, region_id
-    ))
+        '--fetching data from cache %s@%s',
+        split_obj.original_id, region_id
+    )
     split_data = fetch_split_cache_data(
         region_id,
         split_obj.original_id,
@@ -402,9 +401,4 @@ def fetch_split_history(
         split_data.copy()
     )
 
-    if fetch_source == api_config.SwitchCCPSource.CREST:
-        logger.info('--Setting CREST datetime')
-        combined_data['date'] = pd.to_datetime(combined_data['date']).\
-            dt.strftime('%Y-%m-%dT%H:%M:%S')
     return combined_data
-

--- a/scripts/create_splitcache.py
+++ b/scripts/create_splitcache.py
@@ -2,6 +2,7 @@
 from os import path, makedirs
 from datetime import datetime
 from enum import Enum
+import logging
 import warnings
 
 from tinydb import TinyDB, Query

--- a/scripts/create_splitcache.py
+++ b/scripts/create_splitcache.py
@@ -115,14 +115,14 @@ def fetch_data(
         (:obj:`pandas.DataFrame`): data for caching
 
     """
-    if data_source == DataSources.CREST:
-        data = fetch_crest(
-            type_id,
-            region_id,
-            data_range,
-            logger
-        )
-    elif data_source == DataSources.ESI:
+    # if data_source == DataSources.CREST:
+    #     data = fetch_crest(
+    #         type_id,
+    #         region_id,
+    #         data_range,
+    #         logger
+    #     )
+    if data_source == DataSources.ESI:
         data = fetch_esi(
             type_id,
             region_id,
@@ -148,39 +148,39 @@ def fetch_data(
     return data
 
 CREST_MAX = 400
-def fetch_crest(
-        type_id,
-        region_id,
-        data_range=400,
-        logger=LOGGER
-):
-    """fetch data from CREST endpoint
+# def fetch_crest(
+#         type_id,
+#         region_id,
+#         data_range=400,
+#         logger=LOGGER
+# ):
+#     """fetch data from CREST endpoint
 
-    Args:
-        type_id (int): EVE Online type_id
-        region_id (int): EVE Online region_id
-        data_range (int, optional): days of back-propogation
-        logger (:obj:`logging.logger`, optional) logging handle
+#     Args:
+#         type_id (int): EVE Online type_id
+#         region_id (int): EVE Online region_id
+#         data_range (int, optional): days of back-propogation
+#         logger (:obj:`logging.logger`, optional) logging handle
 
-    Returns:
-        (:obj:`pandas.DataFrame`): data from endpoint
+#     Returns:
+#         (:obj:`pandas.DataFrame`): data from endpoint
 
-    """
-    logger.info('--Fetching price history: CREST')
-    if data_range > CREST_MAX:
-        warning_msg = 'CREST only returns %d days' % CREST_MAX
-        warnings.warn(warning_msg, UserWarning)
-        logger.warning(warning_msg)
+#     """
+#     logger.info('--Fetching price history: CREST')
+#     if data_range > CREST_MAX:
+#         warning_msg = 'CREST only returns %d days' % CREST_MAX
+#         warnings.warn(warning_msg, UserWarning)
+#         logger.warning(warning_msg)
 
-    data = crest_utils.fetch_market_history(
-        region_id,
-        type_id,
-        mode=api_utils.SwitchCCPSource.CREST,
-        config=CONFIG,
-        logger=logger
-    )
+#     data = crest_utils.fetch_market_history(
+#         region_id,
+#         type_id,
+#         mode=api_utils.SwitchCCPSource.CREST,
+#         config=CONFIG,
+#         logger=logger
+#     )
 
-    return data.tail(n=data_range)
+#     return data.tail(n=data_range)
 
 def fetch_esi(
         type_id,
@@ -209,7 +209,6 @@ def fetch_esi(
     data = crest_utils.fetch_market_history(
         region_id,
         type_id,
-        mode=api_utils.SwitchCCPSource.ESI,
         config=CONFIG,
         logger=logger
     )

--- a/scripts/create_splitcache.py
+++ b/scripts/create_splitcache.py
@@ -17,10 +17,10 @@ import publicAPI.config as api_utils
 HERE = path.abspath(path.dirname(__file__))
 ROOT = path.dirname(HERE)
 
-LOGGER = p_logging.DEFAULT_LOGGER
 CACHE_PATH = path.join(ROOT, 'publicAPI', 'cache')
 CONFIG = p_config.ProsperConfig(path.join(HERE, 'app.cfg'))
 makedirs(CACHE_PATH, exist_ok=True)
+PROGNAME = 'splitcache_helper'
 
 REGION_LIST = [
     10000001,   #'Derelik',
@@ -101,7 +101,7 @@ def fetch_data(
         region_id,
         data_range,
         data_source,
-        logger=LOGGER
+        logger=logging.getLogger(PROGNAME)
 ):
     """fetch/crunch data for cache
 
@@ -109,19 +109,12 @@ def fetch_data(
         type_id (int): EVE Online type_id for data
         data_range (int): days of back-propogation to fetch
         data_source (:enum:`DataSources`): which data source to fetch
-        logger (:obj:`logging.logger`, optional): logging handle for printing
+        logger (:obj:`logging.logger`): logging handle for printing
 
     Returns:
-        (:obj:`pandas.DataFrame`): data for caching
+        pandas.DataFrame: data for caching
 
     """
-    # if data_source == DataSources.CREST:
-    #     data = fetch_crest(
-    #         type_id,
-    #         region_id,
-    #         data_range,
-    #         logger
-    #     )
     if data_source == DataSources.ESI:
         data = fetch_esi(
             type_id,
@@ -148,45 +141,11 @@ def fetch_data(
     return data
 
 CREST_MAX = 400
-# def fetch_crest(
-#         type_id,
-#         region_id,
-#         data_range=400,
-#         logger=LOGGER
-# ):
-#     """fetch data from CREST endpoint
-
-#     Args:
-#         type_id (int): EVE Online type_id
-#         region_id (int): EVE Online region_id
-#         data_range (int, optional): days of back-propogation
-#         logger (:obj:`logging.logger`, optional) logging handle
-
-#     Returns:
-#         (:obj:`pandas.DataFrame`): data from endpoint
-
-#     """
-#     logger.info('--Fetching price history: CREST')
-#     if data_range > CREST_MAX:
-#         warning_msg = 'CREST only returns %d days' % CREST_MAX
-#         warnings.warn(warning_msg, UserWarning)
-#         logger.warning(warning_msg)
-
-#     data = crest_utils.fetch_market_history(
-#         region_id,
-#         type_id,
-#         mode=api_utils.SwitchCCPSource.CREST,
-#         config=CONFIG,
-#         logger=logger
-#     )
-
-#     return data.tail(n=data_range)
-
 def fetch_esi(
         type_id,
         region_id,
         data_range=400,
-        logger=LOGGER
+        logger=logging.getLogger(PROGNAME)
 ):
     """fetch data from ESI endpoint
 
@@ -194,10 +153,10 @@ def fetch_esi(
         type_id (int): EVE Online type_id
         region_id (int): EVE Online region_id
         data_range (int, optional): days of back-propogation
-        logger (:obj:`logging.logger`, optional) logging handle
+        logger (:obj:`logging.logger`) logging handle
 
     Returns:
-        (:obj:`pandas.DataFrame`): data from endpoint
+        pandas.DataFrame: data from endpoint
 
     """
     logger.info('--Fetching price history: ESI')
@@ -219,7 +178,7 @@ def fetch_emd(
         type_id,
         region_id,
         data_range=400,
-        logger=LOGGER
+        logger=logging.getLogger(PROGNAME)
 ):
     """fetch data from eve-marketdata endpoint
 
@@ -227,10 +186,10 @@ def fetch_emd(
         type_id (int): EVE Online type_id
         region_id (int): EVE Online region_id
         data_range (int, optional): days of back-propogation
-        logger (:obj:`logging.logger`, optional) logging handle
+        logger (:obj:`logging.logger`) logging handle
 
     Returns:
-        (:obj:`pandas.DataFrame`): data from endpoint
+        pandas.DataFrame: data from endpoint
 
     """
     logger.info('--Fetching price history: EMD')
@@ -251,7 +210,7 @@ def write_to_cache_file(
         cache_path,
         type_id=0,
         region_id=0,
-        logger=LOGGER
+        logger=logging.getLogger(PROGNAME)
 ):
     """save data to tinyDB
 
@@ -260,7 +219,7 @@ def write_to_cache_file(
         cache_path (str): path to cache file
         type_id (int, optional): EVE Online type_id
         region_id (int, optional): EVE Online region_id
-        logger (:obj:`logging.logger`, optional): logging handle
+        logger (:obj:`logging.logger`): logging handle
 
     Returns:
         None
@@ -359,20 +318,19 @@ class SplitCache(cli.Application):
 
     def main(self):
         """application runtime"""
-        global LOGGER
-        LOGGER = self.__log_builder.logger
+        logger = self.__log_builder.logger
 
-        LOGGER.info('hello world')
+        logger.info('hello world')
 
         for region_id in cli.terminal.Progress(self.region_list):
             for type_id in self.type_id:
-                LOGGER.info('Fetching: {0}@{1}'.format(type_id, region_id))
+                logger.info('Fetching: {0}@{1}'.format(type_id, region_id))
                 data = fetch_data(
                     type_id,
                     region_id,
                     self.back_range,
                     self.data_source,
-                    LOGGER
+                    logger
                 )
                 if self.force:
                     ## WARNING: deletes old cache values ##
@@ -381,13 +339,13 @@ class SplitCache(cli.Application):
                         self.cache_path,
                         type_id=type_id,
                         region_id=region_id,
-                        logger=LOGGER
+                        logger=logger
                     )
                 else:
                     write_to_cache_file(
                         data,
                         self.cache_path,
-                        logger=LOGGER
+                        logger=logger
                     )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from codecs import open
 import importlib
 from os import path, listdir
+import platform
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
@@ -79,7 +80,12 @@ class PyTest(TestCommand):
             'tests',
             '--cov=publicAPI/',
             '--cov-report=term-missing'
-        ]    #load defaults here
+        ]
+        if platform.system() == 'Windows':
+            self.pytest_args.extend([
+                '-p',
+                'no:logging',
+            ])
 
     def run_tests(self):
         import shlex
@@ -131,13 +137,13 @@ setup(
         'Flask',
         'Flask-RESTful',
         'flask-script',
-        'requests',         #intelpython3 == 2.10.0
-        'pandas',           #intelpython3 == 0.18.1
-        'numpy',            #intelpython3 == 1.11.1
-        'cython>=0.24',             #intelpython3 == 0.24
-        'matplotlib>=2.0.0',        #required for building fbprophet (intel==1.5.1)
+        'requests',             #intelpython3 == 2.10.0
+        'pandas',               #intelpython3 == 0.18.1
+        'numpy',                #intelpython3 == 1.11.1
+        'cython>=0.24',         #intelpython3 == 0.24
+        'matplotlib>=2.0.0',    #required for building fbprophet (intel==1.5.1)
         'pystan>=2.14.0',
-        'fbprophet>=0.1.post1',     #order matters: need pystan/cython first
+        'fbprophet>=0.1.post1', #order matters: need pystan/cython first
         'tinydb',
         'tinymongo',
         'ujson',
@@ -146,7 +152,7 @@ setup(
         'retrying',
     ],
     tests_require=[
-        'pytest',
+        'pytest',  # >=3.0.0,<3.2.0',
         'pytest_cov',        #requires requests==2.13.0
         'pytest-flask',
         'pymysql',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from codecs import open
 import importlib
 from os import path, listdir
-import platform
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
@@ -15,10 +14,10 @@ def get_version(package_name):
     """find __version__ for making package
 
     Args:
-        package_path (str): path to _version.py folder (abspath > relpath)
+        package_name (str): path to _version.py folder (abspath > relpath)
 
     Returns:
-        (str) __version__ value
+        str: __version__ value
 
     """
     module = package_name + '._version'
@@ -34,7 +33,7 @@ def hack_find_packages(include_str):
     setuptools.find_packages(path='') doesn't work as intended
 
     Returns:
-        (:obj:`list` :obj:`str`) append <include_str>. onto every element of setuptools.find_pacakges() call
+        list: append <include_str>. onto every element of setuptools.find_pacakges() call
 
     """
     new_list = [include_str]
@@ -50,7 +49,7 @@ def include_all_subfiles(*args):
         Not recursive, only includes flat files
 
     Returns:
-        (:obj:`list` :obj:`str`) list of all non-directories in a file
+        list: list of all non-directories in a file
 
     """
     file_list = []
@@ -71,7 +70,7 @@ class PyTest(TestCommand):
     http://doc.pytest.org/en/latest/goodpractices.html#manual-integration
 
     """
-    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
+    user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -79,22 +78,17 @@ class PyTest(TestCommand):
             '-rx',
             'tests',
             '--cov=publicAPI/',
-            '--cov-report=term-missing'
+            '--cov-report=term-missing',
+            '--cov-config=.coveragerc',
         ]
-        #if platform.system() == 'Windows':
-        #    self.pytest_args.extend([
-        #        '-p',
-        #        'no:logging',
-        #    ])
 
     def run_tests(self):
         import shlex
-        #import here, cause outside the eggs aren't loaded
         import pytest
         pytest_commands = []
-        try:    #read commandline
+        try:
             pytest_commands = shlex.split(self.pytest_args)
-        except AttributeError:  #use defaults
+        except AttributeError:
             pytest_commands = self.pytest_args
         errno = pytest.main(pytest_commands)
         exit(errno)
@@ -128,7 +122,7 @@ setup(
         'publicAPI':[
             'split_info.json',
             'cache/prosperAPI.json',    #including key file for installer
-            'cache/splitcache.json'
+            'cache/splitcache.json',
         ]
     },
     python_requires='>=3.5',
@@ -158,6 +152,6 @@ setup(
         'pymysql',
     ],
     cmdclass={
-        'test':PyTest
-    }
+        'test':PyTest,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,8 @@ setup(
         'numpy',                #intelpython3 == 1.11.1
         'cython>=0.24',         #intelpython3 == 0.24
         'matplotlib>=2.0.0',    #required for building fbprophet (intel==1.5.1)
-        'pystan==2.14.0',
-        'fbprophet>=0.1.post1', #order matters: need pystan/cython first
+        'pystan==2.15.0',
+        'fbprophet>=0.3.post1', #order matters: need pystan/cython first
         'tinydb',
         'tinymongo',
         'ujson',

--- a/setup.py
+++ b/setup.py
@@ -125,30 +125,31 @@ setup(
             'cache/splitcache.json'
         ]
     },
+    python_requires='>=3.5',
     install_requires=[
-        'ProsperCommon~=1.1.0',
-        'Flask~=0.12',
-        'Flask-RESTful~=0.3.5',
-        'flask-script~=2.0.5',
-        'requests~=2.13.0',         #intelpython3 == 2.10.0
-        'pandas==0.18.1',           #intelpython3 == 0.18.1
-        'numpy==1.11.1',            #intelpython3 == 1.11.1
-        'cython==0.24',             #intelpython3 == 0.24
-        'matplotlib~=2.0.0',        #required for building fbprophet (intel==1.5.1)
-        'pystan~=2.14.0',
-        'fbprophet~=0.1.post1',     #order matters: need pystan/cython first
-        'tinydb~=3.2.2',
-        'tinymongo~=0.1.8.dev0',
-        'ujson~=1.35',
-        'plumbum~=1.6.3',
-        'shortuuid~=0.5.0',
-        'retrying ~= 1.3.3'
+        'ProsperCommon~=1.4.0',
+        'Flask',
+        'Flask-RESTful',
+        'flask-script',
+        'requests',         #intelpython3 == 2.10.0
+        'pandas',           #intelpython3 == 0.18.1
+        'numpy',            #intelpython3 == 1.11.1
+        'cython>=0.24',             #intelpython3 == 0.24
+        'matplotlib>=2.0.0',        #required for building fbprophet (intel==1.5.1)
+        'pystan>=2.14.0',
+        'fbprophet>=0.1.post1',     #order matters: need pystan/cython first
+        'tinydb',
+        'tinymongo',
+        'ujson',
+        'plumbum',
+        'shortuuid',
+        'retrying',
     ],
     tests_require=[
-        'pytest>=3.0.0',
-        'pytest_cov~=2.4.0',        #requires requests==2.13.0
-        'pytest-flask~=0.10.0',
-        'pymysql~=0.7.10'
+        'pytest',
+        'pytest_cov',        #requires requests==2.13.0
+        'pytest-flask',
+        'pymysql',
     ],
     cmdclass={
         'test':PyTest

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ class PyTest(TestCommand):
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.pytest_args = [
-            '-rx',
+            '-rxs',
             'tests',
             '--cov=publicAPI/',
             '--cov-report=term-missing',
@@ -98,7 +98,7 @@ class FastTest(PyTest):
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.pytest_args = [
-            '-rx',
+            '-rxs',
             'tests',
             '-m',
             'not prophet',

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,19 @@ class PyTest(TestCommand):
         errno = pytest.main(pytest_commands)
         exit(errno)
 
+class FastTest(PyTest):
+    """pytest mode that skips prophet tests"""
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = [
+            '-rx',
+            'tests',
+            '-m',
+            'not prophet',
+            '--cov=publicAPI/',
+            '--cov-report=term-missing',
+            '--cov-config=.coveragerc',
+        ]
 with open('README.rst', 'r', 'utf-8') as f:
     README = f.read()
 
@@ -153,5 +166,6 @@ setup(
     ],
     cmdclass={
         'test':PyTest,
+        'fast':FastTest,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
         'numpy',                #intelpython3 == 1.11.1
         'cython>=0.24',         #intelpython3 == 0.24
         'matplotlib>=2.0.0',    #required for building fbprophet (intel==1.5.1)
-        'pystan>=2.14.0',
+        'pystan==2.14.0',
         'fbprophet>=0.1.post1', #order matters: need pystan/cython first
         'tinydb',
         'tinymongo',

--- a/setup.py
+++ b/setup.py
@@ -81,11 +81,11 @@ class PyTest(TestCommand):
             '--cov=publicAPI/',
             '--cov-report=term-missing'
         ]
-        if platform.system() == 'Windows':
-            self.pytest_args.extend([
-                '-p',
-                'no:logging',
-            ])
+        #if platform.system() == 'Windows':
+        #    self.pytest_args.extend([
+        #        '-p',
+        #        'no:logging',
+        #    ])
 
     def run_tests(self):
         import shlex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def app():
         local_configs=p_config.ProsperConfig(
             path.join(ROOT, 'scripts', 'app.cfg')
         ),
-        testmode=True
+        testmode=True,
     )
     return my_app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """configtest.py: setup pytest defaults/extensions"""
 from os import path
+import logging
+import copy
 
 from publicAPI import create_app
 import publicAPI.config as api_config
@@ -24,13 +26,13 @@ def app():
     return my_app
 
 def pytest_runtest_makereport(item, call):
-    if "incremental" in item.keywords:
+    if 'incremental' in item.keywords:
         if call.excinfo is not None:
             parent = item.parent
             parent._previousfailed = item
 
 def pytest_runtest_setup(item):
-    if "incremental" in item.keywords:
-        previousfailed = getattr(item.parent, "_previousfailed", None)
+    if 'incremental' in item.keywords:
+        previousfailed = getattr(item.parent, '_previousfailed', None)
         if previousfailed is not None:
-            pytest.xfail("previous test failed (%s)" %previousfailed.name)
+            pytest.xfail('previous test failed (%s)' % previousfailed.name)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,7 +61,7 @@ def get_config(config_filename):
         config_filename (str): path to config file
 
     Returns:
-        (:obj:`configparser.ConfigParser`)
+        prosper.common.ProsperConfig: a ConfigParser like object
 
     """
     config = p_config.ProsperConfig(config_filename)
@@ -83,7 +83,7 @@ def check_db_values(
         config (:obj:`configparser.ConfigParser`): db info
 
     Returns:
-        (:obj:`list`) data from db (or None if no creds)
+        list: data from db (or None if no creds)
 
     """
     try:

--- a/tests/test_crest_endpoint.py
+++ b/tests/test_crest_endpoint.py
@@ -184,14 +184,12 @@ def test_get_api_key():
     connection.close()
     TEST_API_KEY = test_key
 
+@pytest.mark.prophet
 @pytest.mark.usefixtures('client_class')
 class TestProphetcsv:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
         """exercise `collect_stats`"""
-#        if platform.system() == 'Darwin':
-#            pytest.xfail('Unable to run fbprophet on mac')
-
         test_clear_caches()
         assert TEST_API_KEY != ''
         global VIRGIN_RUNTIME
@@ -307,6 +305,7 @@ class TestProphetcsv:
         )
         assert req._status_code == 405
 
+@pytest.mark.prophet
 @pytest.mark.usefixtures('client_class')
 class TestProphetjson:
     """test framework for collecting endpoint stats"""

--- a/tests/test_crest_endpoint.py
+++ b/tests/test_crest_endpoint.py
@@ -35,6 +35,7 @@ def test_clear_caches():
 VIRGIN_RUNTIME = None
 
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCcsv:
     """test framework for collecting endpoint stats"""
     def test_odbc_happypath(self):
@@ -116,6 +117,7 @@ class TestODBCcsv:
         assert req._status_code == 405
 
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCjson:
     """test framework for collecting endpoint stats"""
     def test_odbc_happypath(self):
@@ -191,6 +193,7 @@ DEMO_UNSPLIT = {
     "split_rate": 10
 }
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCsplit:
     """make sure behavior for splits is maintained"""
     demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)
@@ -257,6 +260,7 @@ def test_get_api_key():
     TEST_API_KEY = test_key
 
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetcsv:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
@@ -394,6 +398,7 @@ class TestProphetcsv:
         assert req._status_code == 405
 
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetjson:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
@@ -517,6 +522,7 @@ class TestProphetjson:
         assert req._status_code == 413
 
 @pytest.mark.usefixtures('client_class')
+@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetSplit:
     """make sure behavior for splits is maintained"""
     demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)

--- a/tests/test_crest_endpoint.py
+++ b/tests/test_crest_endpoint.py
@@ -35,7 +35,6 @@ def test_clear_caches():
 VIRGIN_RUNTIME = None
 
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCcsv:
     """test framework for collecting endpoint stats"""
     def test_odbc_happypath(self):
@@ -117,7 +116,6 @@ class TestODBCcsv:
         assert req._status_code == 405
 
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCjson:
     """test framework for collecting endpoint stats"""
     def test_odbc_happypath(self):
@@ -175,25 +173,24 @@ class TestODBCjson:
 DAYS_SINCE_SPLIT = 10
 TEST_DATE = datetime.utcnow() - timedelta(days=DAYS_SINCE_SPLIT)
 DEMO_SPLIT = {
-    "type_id":35,
-    "type_name":"Tritanium",
-    "original_id":34,
-    "new_id":35,
-    "split_date":TEST_DATE.strftime('%Y-%m-%d'),
-    "bool_mult_div":"False",
-    "split_rate": 10
+    'type_id':35,
+    'type_name':'Tritanium',
+    'original_id':34,
+    'new_id':35,
+    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
+    'bool_mult_div':'False',
+    'split_rate': 10
 }
 DEMO_UNSPLIT = {
-"type_id":35,
-    "type_name":"Tritanium",
-    "original_id":34,
-    "new_id":35,
-    "split_date":TEST_DATE.strftime('%Y-%m-%d'),
-    "bool_mult_div":"False",
-    "split_rate": 10
+    'type_id':35,
+    'type_name':'Tritanium',
+    'original_id':34,
+    'new_id':35,
+    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
+    'bool_mult_div':'False',
+    'split_rate': 10
 }
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestODBCsplit:
     """make sure behavior for splits is maintained"""
     demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)
@@ -260,7 +257,6 @@ def test_get_api_key():
     TEST_API_KEY = test_key
 
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetcsv:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
@@ -398,7 +394,6 @@ class TestProphetcsv:
         assert req._status_code == 405
 
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetjson:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
@@ -522,7 +517,6 @@ class TestProphetjson:
         assert req._status_code == 413
 
 @pytest.mark.usefixtures('client_class')
-@pytest.mark.filterwarnings('ignore:DeprecationWarning')
 class TestProphetSplit:
     """make sure behavior for splits is maintained"""
     demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)

--- a/tests/test_crest_endpoint.py
+++ b/tests/test_crest_endpoint.py
@@ -11,7 +11,6 @@ import pytest
 from flask import url_for
 
 import publicAPI.exceptions as exceptions
-import publicAPI.split_utils as split_utils
 import publicAPI.config as api_utils
 import helpers
 
@@ -170,77 +169,6 @@ class TestODBCjson:
         )
         assert req._status_code == 404
 
-DAYS_SINCE_SPLIT = 10
-TEST_DATE = datetime.utcnow() - timedelta(days=DAYS_SINCE_SPLIT)
-DEMO_SPLIT = {
-    'type_id':35,
-    'type_name':'Tritanium',
-    'original_id':34,
-    'new_id':35,
-    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
-    'bool_mult_div':'False',
-    'split_rate': 10
-}
-DEMO_UNSPLIT = {
-    'type_id':35,
-    'type_name':'Tritanium',
-    'original_id':34,
-    'new_id':35,
-    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
-    'bool_mult_div':'False',
-    'split_rate': 10
-}
-@pytest.mark.usefixtures('client_class')
-class TestODBCsplit:
-    """make sure behavior for splits is maintained"""
-    demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)
-    revrsplit_obj = split_utils.SplitInfo(DEMO_UNSPLIT)
-    def test_validate_forward_split(self):
-        """run split as intended, new item with split in the past"""
-        # vv FIXME vv: depends on split_utils package
-        api_utils.SPLIT_INFO = split_utils.read_split_info()
-        api_utils.SPLIT_INFO[self.demosplit_obj.type_id] = self.demosplit_obj
-        # ^^ FIXME ^^ #
-        req = self.client.get(
-            url_for('ohlc_endpoint', return_type='csv') +
-            '?typeID={type_id}&regionID={region_id}'.format(
-                type_id=self.demosplit_obj.type_id,
-                #type_id=CONFIG.get('TEST', 'type_id'),
-                region_id=CONFIG.get('TEST', 'region_id')
-            )
-        )
-
-        data = None
-        with io.StringIO(req.data.decode()) as buff:
-            data = pd.read_csv(buff)
-
-        assert req._status_code == 200
-        #TODO: validate return
-
-    def test_validate_reverse_split(self):
-        """run split normally, old item with forward data"""
-        # vv FIXME vv: depends on split_utils package
-        api_utils.SPLIT_INFO = split_utils.read_split_info()
-        api_utils.SPLIT_INFO[self.demosplit_obj.type_id] = self.demosplit_obj
-        # ^^ FIXME ^^ #
-        req = self.client.get(
-            url_for('ohlc_endpoint', return_type='csv') +
-            '?typeID={type_id}&regionID={region_id}'.format(
-                type_id=self.demosplit_obj.original_id,
-                #type_id=CONFIG.get('TEST', 'type_id'),
-                region_id=CONFIG.get('TEST', 'region_id')
-            )
-        )
-
-        data = None
-        with io.StringIO(req.data.decode()) as buff:
-            data = pd.read_csv(buff)
-
-        assert req._status_code == 200
-        #TODO: validate return
-
-
-
 TEST_API_KEY = ''
 def test_get_api_key():
     """fetch api key from cache for testing"""
@@ -261,8 +189,8 @@ class TestProphetcsv:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
+#        if platform.system() == 'Darwin':
+#            pytest.xfail('Unable to run fbprophet on mac')
 
         test_clear_caches()
         assert TEST_API_KEY != ''
@@ -299,9 +227,6 @@ class TestProphetcsv:
 
     def test_prophet_happypath_cached(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         fetch_start = time.time()
         req = self.client.get(
             url_for('prophetendpoint', return_type='csv') +
@@ -319,9 +244,6 @@ class TestProphetcsv:
 
     def test_prophet_bad_regionid(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         req = self.client.get(
             url_for('prophetendpoint', return_type='csv') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -335,8 +257,6 @@ class TestProphetcsv:
 
     def test_prophet_bad_typeid(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
         req = self.client.get(
             url_for('prophetendpoint', return_type='csv') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -350,8 +270,6 @@ class TestProphetcsv:
 
     def test_prophet_bad_api(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
         req = self.client.get(
             url_for('prophetendpoint', return_type='csv') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -365,8 +283,6 @@ class TestProphetcsv:
 
     def test_prophet_bad_range(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
         req = self.client.get(
             url_for('prophetendpoint', return_type='csv') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -380,8 +296,6 @@ class TestProphetcsv:
 
     def test_prophet_bad_format(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
         req = self.client.get(
             url_for('prophetendpoint', return_type='butts') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -398,9 +312,6 @@ class TestProphetjson:
     """test framework for collecting endpoint stats"""
     def test_prophet_happypath(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         test_clear_caches()
         global VIRGIN_RUNTIME
         fetch_start = time.time()
@@ -434,9 +345,6 @@ class TestProphetjson:
 
     def test_prophet_happypath_cached(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         fetch_start = time.time()
         req = self.client.get(
             url_for('prophetendpoint', return_type='json') +
@@ -454,9 +362,6 @@ class TestProphetjson:
 
     def test_prophet_bad_regionid(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         req = self.client.get(
             url_for('prophetendpoint', return_type='json') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -470,9 +375,6 @@ class TestProphetjson:
 
     def test_prophet_bad_typeid(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         req = self.client.get(
             url_for('prophetendpoint', return_type='json') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -486,9 +388,6 @@ class TestProphetjson:
 
     def test_prophet_bad_api(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         req = self.client.get(
             url_for('prophetendpoint', return_type='json') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -502,9 +401,6 @@ class TestProphetjson:
 
     def test_prophet_bad_range(self):
         """exercise `collect_stats`"""
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
         req = self.client.get(
             url_for('prophetendpoint', return_type='json') +
             '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
@@ -515,68 +411,3 @@ class TestProphetjson:
             )
         )
         assert req._status_code == 413
-
-@pytest.mark.usefixtures('client_class')
-class TestProphetSplit:
-    """make sure behavior for splits is maintained"""
-    demosplit_obj = split_utils.SplitInfo(DEMO_SPLIT)
-    revrsplit_obj = split_utils.SplitInfo(DEMO_UNSPLIT)
-    def test_validate_forward_split(self):
-        """run split as intended, new item with split in the past"""
-
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
-        test_clear_caches()
-        assert TEST_API_KEY != ''
-
-        # vv FIXME vv: depends on split_utils package
-        api_utils.SPLIT_INFO = split_utils.read_split_info()
-        api_utils.SPLIT_INFO[self.demosplit_obj.type_id] = self.demosplit_obj
-        # ^^ FIXME ^^ #
-
-        req = self.client.get(
-            url_for('prophetendpoint', return_type='csv') +
-            '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
-                type_id=self.demosplit_obj.type_id,
-                region_id=CONFIG.get('TEST', 'region_id'),
-                api_key=TEST_API_KEY,
-                range=CONFIG.get('TEST', 'forecast_range')
-            )
-        )
-
-        data = None
-        with io.StringIO(req.data.decode()) as buff:
-            data = pd.read_csv(buff)
-
-        assert req._status_code == 200
-
-    def test_validate_reverse_split(self):
-        """run split as intended, old item with new data"""
-
-        if platform.system() == 'Darwin':
-            pytest.xfail('Unable to run fbprophet on mac')
-
-        test_clear_caches()
-        assert TEST_API_KEY != ''
-
-        # vv FIXME vv: depends on split_utils package
-        api_utils.SPLIT_INFO = split_utils.read_split_info()
-        api_utils.SPLIT_INFO[self.demosplit_obj.type_id] = self.demosplit_obj
-        # ^^ FIXME ^^ #
-
-        req = self.client.get(
-            url_for('prophetendpoint', return_type='csv') +
-            '?typeID={type_id}&regionID={region_id}&api={api_key}&range={range}'.format(
-                type_id=self.demosplit_obj.original_id,
-                region_id=CONFIG.get('TEST', 'region_id'),
-                api_key=TEST_API_KEY,
-                range=CONFIG.get('TEST', 'forecast_range')
-            )
-        )
-
-        data = None
-        with io.StringIO(req.data.decode()) as buff:
-            data = pd.read_csv(buff)
-
-        assert req._status_code == 200

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -288,7 +288,7 @@ class TestValidateID:
 
     def test_happypath_types(self):
         """make sure behavior is expected for direct use"""
-        pytest.skip('CREST endpoint deprecated')
+        #pytest.skip('CREST endpoint deprecated')
         type_info = crest_utils.validate_id(
             'inventory_types',
             self.type_id,
@@ -308,7 +308,6 @@ class TestValidateID:
             self.type_id,
             cache_buster=True,
             config=ROOT_CONFIG,
-            mode=api_config.SwitchCCPSource.ESI
         )
         print(type_info)
         print(type_info_esi)

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -1,3 +1,5 @@
+"""tests for crest_utils.py"""
+
 from os import path, makedirs, rmdir
 from shutil import rmtree
 from datetime import datetime, timedelta
@@ -14,6 +16,7 @@ import publicAPI.crest_utils as crest_utils
 import publicAPI.exceptions as exceptions
 import helpers
 
+
 HERE = path.abspath(path.dirname(__file__))
 ROOT = path.dirname(HERE)
 
@@ -22,92 +25,6 @@ CONFIG = helpers.get_config(CONFIG_FILENAME)
 ROOT_CONFIG = helpers.get_config(
     path.join(ROOT, 'scripts', 'app.cfg'))
 
-def test_validate_crest_fetcher(config=CONFIG):
-    """exercise fetch_crest_endpoint"""
-    pytest.skip('CREST Deprecated')
-    region_data = crest_utils.fetch_crest_endpoint(
-        'map_regions',
-        region_id=config.get('TEST', 'region_id'),
-        config=ROOT_CONFIG
-    )
-    region_keys = [ #not all keys, just important ones
-        'name',
-        'description',
-        'marketHistory',
-        'marketOrdersAll',
-        'constellations'
-    ]
-    for key in region_keys:
-        assert key in region_data.keys()
-    assert region_data['name'] == 'The Forge'
-
-    types_data = crest_utils.fetch_crest_endpoint(
-        'inventory_types',
-        type_id=config.get('TEST', 'type_id'),
-        config=ROOT_CONFIG
-    )
-    type_keys = [ #not all keys, just important ones
-        'capacity',
-        'description',
-        'iconID',
-        'portionSize',
-        'volume',
-        'dogma',
-        'radius',
-        'published',
-        'mass',
-        'id',
-        'name'
-    ]
-    for key in type_keys:
-        assert key in types_data.keys()
-    assert types_data['name'] == 'Tritanium'
-
-    market_data = crest_utils.fetch_crest_endpoint(
-        'market_history',
-        type_id=config.get('TEST', 'type_id'),
-        region_id=config.get('TEST', 'region_id'),
-        config=ROOT_CONFIG
-    )
-    market_keys = [ #not all keys, just important ones
-        'items',
-        'pageCount',
-        'totalCount'
-    ]
-    for key in market_keys:
-        assert key in market_data.keys()
-    assert len(market_data['items']) == market_data['totalCount']
-
-def test_crest_fetcher_errors(config=CONFIG):
-    """validate errors thrown by fetch_crest_endpoint"""
-    pytest.skip('CREST Deprecated')
-    with pytest.raises(exceptions.UnsupportedCrestEndpoint):
-        data = crest_utils.fetch_crest_endpoint(
-            'butts',
-            region_id=config.get('TEST', 'region_id'),
-            config=ROOT_CONFIG
-        )
-
-    with pytest.raises(exceptions.CrestAddressError):
-        data = crest_utils.fetch_crest_endpoint(
-            'inventory_types',
-            region_id=config.get('TEST', 'region_id'),
-            config=ROOT_CONFIG
-        )
-
-    with pytest.raises(exceptions.CrestAddressError):
-        data = crest_utils.fetch_crest_endpoint(
-            'market_history',
-            region_id=config.get('TEST', 'region_id'),
-            config=ROOT_CONFIG
-        )
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        data = crest_utils.fetch_crest_endpoint(
-            'inventory_types',
-            type_id=config.get('TEST', 'bad_typeid'),
-            config=ROOT_CONFIG
-        )
 
 def test_validate_esi_fetcher(config=CONFIG):
     """exercise fetch_crest_endpoint"""
@@ -283,8 +200,6 @@ class TestValidateID:
     def test_clear_cachefiles(self):
         """init test, clean up paths before test"""
         helpers.clear_caches()
-        #rmtree(TEST_CACHE_PATH)
-        #makedirs(TEST_CACHE_PATH)
 
     def test_happypath_types(self):
         """make sure behavior is expected for direct use"""
@@ -312,13 +227,6 @@ class TestValidateID:
         print(type_info)
         print(type_info_esi)
         assert type_info == type_info_esi
-        #assert type_info_esi['name'] == type_info['name']
-        #assert type_info_esi['description'] == type_info['description']
-        #assert type_info_esi['published'] == type_info['published']
-        #assert type_info_esi['radius'] == type_info['radius']
-        #assert type_info_esi['icon_id'] == type_info['iconID']
-        #assert type_info_esi['capacity'] == type_info['capacity']
-        #assert type_info_esi['type_id'] == type_info['id']
 
     def test_happypath_regions(self):
         """make sure behavior is good for regions too"""
@@ -397,40 +305,6 @@ class TestValidateID:
 
         assert type_info == type_cache['payload']
 
-#def test_fetch_market_history(config=CONFIG):
-#    """test `fetch_market_history` utility"""
-#    #pytest.skip('CREST Deprecated')
-#    data = crest_utils.fetch_market_history(
-#        config.get('TEST', 'region_id'),
-#        config.get('TEST', 'type_id'),
-#        config=ROOT_CONFIG
-#    )
-#
-#    assert isinstance(data, pd.DataFrame)
-#    expected_cols = [
-#        'date',
-#        'avgPrice',
-#        'highPrice',
-#        'lowPrice',
-#        'volume',
-#        'orders'
-#        #extra keys:
-#        #'volume_str',
-#        #'orderCountStr'
-#    ]
-#    for key in expected_cols:
-#        assert key in data.columns.values
-#
-#    ohlc = crest_utils.data_to_ohlc(data)
-#
-#    assert ohlc['date'].equals(data['date'])
-#    assert ohlc['open'].equals(data['avgPrice'])
-#    assert ohlc['high'].equals(data['highPrice'])
-#    assert ohlc['low'].equals(data['lowPrice'])
-#    assert ohlc['volume'].equals(data['volume'])
-#
-#    assert data['avgPrice'].shift(1).equals(ohlc['close'])
-#
 def test_fetch_market_history_esi(config=CONFIG):
     """test `fetch_market_history` utility"""
 

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -24,6 +24,7 @@ ROOT_CONFIG = helpers.get_config(
 
 def test_validate_crest_fetcher(config=CONFIG):
     """exercise fetch_crest_endpoint"""
+    pytest.skip('CREST Deprecated')
     region_data = crest_utils.fetch_crest_endpoint(
         'map_regions',
         region_id=config.get('TEST', 'region_id'),
@@ -79,6 +80,7 @@ def test_validate_crest_fetcher(config=CONFIG):
 
 def test_crest_fetcher_errors(config=CONFIG):
     """validate errors thrown by fetch_crest_endpoint"""
+    pytest.skip('CREST Deprecated')
     with pytest.raises(exceptions.UnsupportedCrestEndpoint):
         data = crest_utils.fetch_crest_endpoint(
             'butts',
@@ -396,7 +398,7 @@ class TestValidateID:
 
 def test_fetch_market_history(config=CONFIG):
     """test `fetch_market_history` utility"""
-
+    pytest.skip('CREST Deprecated')
     data = crest_utils.fetch_market_history(
         config.get('TEST', 'region_id'),
         config.get('TEST', 'type_id'),

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -286,39 +286,39 @@ class TestValidateID:
         #rmtree(TEST_CACHE_PATH)
         #makedirs(TEST_CACHE_PATH)
 
-    def test_happypath_types(self):
-        """make sure behavior is expected for direct use"""
-        pytest.skip('CREST endpoint deprecated')
-        type_info = crest_utils.validate_id(
-            'inventory_types',
-            self.type_id,
-            config=ROOT_CONFIG
-        )
-        assert type_info['name'] == 'Tritanium'
-
-        type_info_retry = crest_utils.validate_id(
-            'inventory_types',
-            self.type_id,
-            config=ROOT_CONFIG
-        )
-        assert type_info_retry == type_info
-
-        type_info_esi = crest_utils.validate_id(
-            'inventory_types',
-            self.type_id,
-            cache_buster=True,
-            config=ROOT_CONFIG,
-            mode=api_config.SwitchCCPSource.ESI
-        )
-        print(type_info)
-        print(type_info_esi)
-        assert type_info_esi['name'] == type_info['name']
-        assert type_info_esi['description'] == type_info['description']
-        assert type_info_esi['published'] == type_info['published']
-        assert type_info_esi['radius'] == type_info['radius']
-        assert type_info_esi['icon_id'] == type_info['iconID']
-        assert type_info_esi['capacity'] == type_info['capacity']
-        assert type_info_esi['type_id'] == type_info['id']
+#    def test_happypath_types(self):
+#        """make sure behavior is expected for direct use"""
+#        pytest.skip('CREST endpoint deprecated')
+#        type_info = crest_utils.validate_id(
+#            'inventory_types',
+#            self.type_id,
+#            config=ROOT_CONFIG
+#        )
+#        assert type_info['name'] == 'Tritanium'
+#
+#        type_info_retry = crest_utils.validate_id(
+#            'inventory_types',
+#            self.type_id,
+#            config=ROOT_CONFIG
+#        )
+#        assert type_info_retry == type_info
+#
+#        type_info_esi = crest_utils.validate_id(
+#            'inventory_types',
+#            self.type_id,
+#            cache_buster=True,
+#            config=ROOT_CONFIG,
+#            mode=api_config.SwitchCCPSource.ESI
+#        )
+#        print(type_info)
+#        print(type_info_esi)
+#        assert type_info_esi['name'] == type_info['name']
+#        assert type_info_esi['description'] == type_info['description']
+#        assert type_info_esi['published'] == type_info['published']
+#        assert type_info_esi['radius'] == type_info['radius']
+#        assert type_info_esi['icon_id'] == type_info['iconID']
+#        assert type_info_esi['capacity'] == type_info['capacity']
+#        assert type_info_esi['type_id'] == type_info['id']
 
     def test_happypath_regions(self):
         """make sure behavior is good for regions too"""
@@ -341,11 +341,10 @@ class TestValidateID:
             self.region_id,
             cache_buster=True,
             config=ROOT_CONFIG,
-            mode=api_config.SwitchCCPSource.ESI
         )
 
-        assert region_info_esi['name']        == region_info['name']
-        assert region_info_esi['region_id']   == region_info['id']
+        assert region_info_esi['name'] == region_info['name']
+        assert region_info_esi['region_id'] == region_info['id']
         assert region_info_esi['description'] == region_info['description']
 
     def test_cache_files(self):
@@ -398,40 +397,40 @@ class TestValidateID:
 
         assert type_info == type_cache['payload']
 
-def test_fetch_market_history(config=CONFIG):
-    """test `fetch_market_history` utility"""
-    pytest.skip('CREST Deprecated')
-    data = crest_utils.fetch_market_history(
-        config.get('TEST', 'region_id'),
-        config.get('TEST', 'type_id'),
-        config=ROOT_CONFIG
-    )
-
-    assert isinstance(data, pd.DataFrame)
-    expected_cols = [
-        'date',
-        'avgPrice',
-        'highPrice',
-        'lowPrice',
-        'volume',
-        'orders'
-        #extra keys:
-        #'volume_str',
-        #'orderCountStr'
-    ]
-    for key in expected_cols:
-        assert key in data.columns.values
-
-    ohlc = crest_utils.data_to_ohlc(data)
-
-    assert ohlc['date'].equals(data['date'])
-    assert ohlc['open'].equals(data['avgPrice'])
-    assert ohlc['high'].equals(data['highPrice'])
-    assert ohlc['low'].equals(data['lowPrice'])
-    assert ohlc['volume'].equals(data['volume'])
-
-    assert data['avgPrice'].shift(1).equals(ohlc['close'])
-
+#def test_fetch_market_history(config=CONFIG):
+#    """test `fetch_market_history` utility"""
+#    #pytest.skip('CREST Deprecated')
+#    data = crest_utils.fetch_market_history(
+#        config.get('TEST', 'region_id'),
+#        config.get('TEST', 'type_id'),
+#        config=ROOT_CONFIG
+#    )
+#
+#    assert isinstance(data, pd.DataFrame)
+#    expected_cols = [
+#        'date',
+#        'avgPrice',
+#        'highPrice',
+#        'lowPrice',
+#        'volume',
+#        'orders'
+#        #extra keys:
+#        #'volume_str',
+#        #'orderCountStr'
+#    ]
+#    for key in expected_cols:
+#        assert key in data.columns.values
+#
+#    ohlc = crest_utils.data_to_ohlc(data)
+#
+#    assert ohlc['date'].equals(data['date'])
+#    assert ohlc['open'].equals(data['avgPrice'])
+#    assert ohlc['high'].equals(data['highPrice'])
+#    assert ohlc['low'].equals(data['lowPrice'])
+#    assert ohlc['volume'].equals(data['volume'])
+#
+#    assert data['avgPrice'].shift(1).equals(ohlc['close'])
+#
 def test_fetch_market_history_esi(config=CONFIG):
     """test `fetch_market_history` utility"""
 
@@ -439,7 +438,6 @@ def test_fetch_market_history_esi(config=CONFIG):
         config.get('TEST', 'region_id'),
         config.get('TEST', 'type_id'),
         config=ROOT_CONFIG,
-        mode=api_config.SwitchCCPSource.ESI
     )
 
     assert isinstance(data, pd.DataFrame)

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -288,6 +288,7 @@ class TestValidateID:
 
     def test_happypath_types(self):
         """make sure behavior is expected for direct use"""
+        pytest.skip('CREST endpoint deprecated')
         type_info = crest_utils.validate_id(
             'inventory_types',
             self.type_id,
@@ -309,14 +310,15 @@ class TestValidateID:
             config=ROOT_CONFIG,
             mode=api_config.SwitchCCPSource.ESI
         )
-
-        assert type_info_esi['name']        == type_info['name']
+        print(type_info)
+        print(type_info_esi)
+        assert type_info_esi['name'] == type_info['name']
         assert type_info_esi['description'] == type_info['description']
-        assert type_info_esi['published']   == type_info['published']
-        assert type_info_esi['radius']      == type_info['radius']
-        assert type_info_esi['icon_id']     == type_info['iconID']
-        assert type_info_esi['capacity']    == type_info['capacity']
-        assert type_info_esi['type_id']     == type_info['id']
+        assert type_info_esi['published'] == type_info['published']
+        assert type_info_esi['radius'] == type_info['radius']
+        assert type_info_esi['icon_id'] == type_info['iconID']
+        assert type_info_esi['capacity'] == type_info['capacity']
+        assert type_info_esi['type_id'] == type_info['id']
 
     def test_happypath_regions(self):
         """make sure behavior is good for regions too"""

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -344,7 +344,7 @@ class TestValidateID:
         )
 
         assert region_info_esi['name'] == region_info['name']
-        assert region_info_esi['region_id'] == region_info['id']
+        assert region_info_esi['region_id'] == region_info['region_id']
         assert region_info_esi['description'] == region_info['description']
 
     def test_cache_files(self):

--- a/tests/test_crest_utils.py
+++ b/tests/test_crest_utils.py
@@ -286,39 +286,40 @@ class TestValidateID:
         #rmtree(TEST_CACHE_PATH)
         #makedirs(TEST_CACHE_PATH)
 
-#    def test_happypath_types(self):
-#        """make sure behavior is expected for direct use"""
-#        pytest.skip('CREST endpoint deprecated')
-#        type_info = crest_utils.validate_id(
-#            'inventory_types',
-#            self.type_id,
-#            config=ROOT_CONFIG
-#        )
-#        assert type_info['name'] == 'Tritanium'
-#
-#        type_info_retry = crest_utils.validate_id(
-#            'inventory_types',
-#            self.type_id,
-#            config=ROOT_CONFIG
-#        )
-#        assert type_info_retry == type_info
-#
-#        type_info_esi = crest_utils.validate_id(
-#            'inventory_types',
-#            self.type_id,
-#            cache_buster=True,
-#            config=ROOT_CONFIG,
-#            mode=api_config.SwitchCCPSource.ESI
-#        )
-#        print(type_info)
-#        print(type_info_esi)
-#        assert type_info_esi['name'] == type_info['name']
-#        assert type_info_esi['description'] == type_info['description']
-#        assert type_info_esi['published'] == type_info['published']
-#        assert type_info_esi['radius'] == type_info['radius']
-#        assert type_info_esi['icon_id'] == type_info['iconID']
-#        assert type_info_esi['capacity'] == type_info['capacity']
-#        assert type_info_esi['type_id'] == type_info['id']
+    def test_happypath_types(self):
+        """make sure behavior is expected for direct use"""
+        pytest.skip('CREST endpoint deprecated')
+        type_info = crest_utils.validate_id(
+            'inventory_types',
+            self.type_id,
+            config=ROOT_CONFIG
+        )
+        assert type_info['name'] == 'Tritanium'
+
+        type_info_retry = crest_utils.validate_id(
+            'inventory_types',
+            self.type_id,
+            config=ROOT_CONFIG
+        )
+        assert type_info_retry == type_info
+
+        type_info_esi = crest_utils.validate_id(
+            'inventory_types',
+            self.type_id,
+            cache_buster=True,
+            config=ROOT_CONFIG,
+            mode=api_config.SwitchCCPSource.ESI
+        )
+        print(type_info)
+        print(type_info_esi)
+        assert type_info == type_info_esi
+        #assert type_info_esi['name'] == type_info['name']
+        #assert type_info_esi['description'] == type_info['description']
+        #assert type_info_esi['published'] == type_info['published']
+        #assert type_info_esi['radius'] == type_info['radius']
+        #assert type_info_esi['icon_id'] == type_info['iconID']
+        #assert type_info_esi['capacity'] == type_info['capacity']
+        #assert type_info_esi['type_id'] == type_info['id']
 
     def test_happypath_regions(self):
         """make sure behavior is good for regions too"""

--- a/tests/test_forecast_utils.py
+++ b/tests/test_forecast_utils.py
@@ -82,35 +82,35 @@ DEMO_DATA = {
     'key': 'typeID,regionID,date',
     'columns': 'typeID,regionID,date,lowPrice,highPrice,avgPrice,volume,orders',
     'result':[
-        {"row": {
-            "typeID": "38",
-            "regionID": "10000002",
-            "date": "2015-03-28",
-            "lowPrice": "674.02",
-            "highPrice": "682.65",
-            "avgPrice": "681.99",
-            "volume": "43401081",
-            "orders": "1808"
+        {'row': {
+            'typeID': '38',
+            'regionID': '10000002',
+            'date': '2015-03-28',
+            'lowPrice': '674.02',
+            'highPrice': '682.65',
+            'avgPrice': '681.99',
+            'volume': '43401081',
+            'orders': '1808'
         }},
-        {"row": {
-            "typeID": "38",
-            "regionID": "10000002",
-            "date": "2015-03-29",
-            "lowPrice": "677.29",
-            "highPrice": "681.95",
-            "avgPrice": "681.89",
-            "volume": "46045538",
-            "orders": "1770"
+        {'row': {
+            'typeID': '38',
+            'regionID': '10000002',
+            'date': '2015-03-29',
+            'lowPrice': '677.29',
+            'highPrice': '681.95',
+            'avgPrice': '681.89',
+            'volume': '46045538',
+            'orders': '1770'
         }},
-        {"row": {
-            "typeID": "38",
-            "regionID": "10000002",
-            "date": "2015-03-30",
-            "lowPrice": "678.93",
-            "highPrice": "684",
-            "avgPrice": "679.14",
-            "volume": "56083217",
-            "orders": "1472"
+        {'row': {
+            'typeID': '38',
+            'regionID': '10000002',
+            'date': '2015-03-30',
+            'lowPrice': '678.93',
+            'highPrice': '684',
+            'avgPrice': '679.14',
+            'volume': '56083217',
+            'orders': '1472'
         }}
     ]
 }

--- a/tests/test_forecast_utils.py
+++ b/tests/test_forecast_utils.py
@@ -135,6 +135,7 @@ def test_parse_emd_data_fail():
 
 TEST_DATA_PATH = path.join(HERE, 'sample_emd_data.csv')
 TEST_PREDICT_PATH = path.join(HERE, 'sample_emd_predict.csv')
+@pytest.mark.prophet
 def test_build_forecast(config=CONFIG):
     """try to build a forecast"""
     test_data = pd.read_csv(TEST_DATA_PATH)
@@ -176,7 +177,7 @@ def test_build_forecast(config=CONFIG):
             #    assert (abs(val) < float_limit) or (np.isnan(val)) #fucking floats
         else:
             assert predict_data[key].equals(expected_prediction[key])
-
+@pytest.mark.prophet
 def test_forecast_truncate(config=CONFIG):
     """make sure truncate functionality works"""
     test_data = pd.read_csv(TEST_DATA_PATH)

--- a/tests/test_forecast_utils.py
+++ b/tests/test_forecast_utils.py
@@ -137,9 +137,6 @@ TEST_DATA_PATH = path.join(HERE, 'sample_emd_data.csv')
 TEST_PREDICT_PATH = path.join(HERE, 'sample_emd_predict.csv')
 def test_build_forecast(config=CONFIG):
     """try to build a forecast"""
-    if platform.system() == 'Darwin':
-        pytest.xfail('Unable to run fbprophet on mac')
-
     test_data = pd.read_csv(TEST_DATA_PATH)
     test_data['date'] = pd.to_datetime(test_data['date'])
     max_date = test_data['date'].max()
@@ -182,9 +179,6 @@ def test_build_forecast(config=CONFIG):
 
 def test_forecast_truncate(config=CONFIG):
     """make sure truncate functionality works"""
-    if platform.system() == 'Darwin':
-        pytest.xfail('Unable to run fbprophet on mac')
-
     test_data = pd.read_csv(TEST_DATA_PATH)
     test_data['date'] = pd.to_datetime(test_data['date'])
     max_date = test_data['date'].max()

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -2,7 +2,6 @@
 from os import path
 from math import floor
 from datetime import datetime, timedelta
-import requests
 from tinydb import TinyDB, Query
 
 import pandas as pd
@@ -252,22 +251,6 @@ class TestNoSplit:
             )
         )
 
-    def test_future_split_crest(self):
-        """validate with CREST source"""
-        test_data_crest = split_utils.fetch_split_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            self.test_type_id,
-            api_utils.SwitchCCPSource.CREST,
-            config=ROOT_CONFIG
-        )
-        assert test_data_crest.equals(
-            crest_utils.fetch_market_history(
-                TEST_CONFIG.get('TEST', 'region_id'),
-                self.test_type_id,
-                config=ROOT_CONFIG
-            )
-        )
-
     def test_future_split_emd(self):
         """valdiate with EMD source"""
         test_data_emd = split_utils.fetch_split_history(
@@ -311,7 +294,7 @@ def days_since_date(date_str):
         date_str (str)
 
     Returns
-        (int) number of days since date
+        int: number of days since date
 
     """
     demo_date = split_utils.datetime_helper(date_str)
@@ -330,7 +313,7 @@ def prep_raw_data(
         min_date (str): datetime to filter to
 
     Returns:
-        clean_data (:obj:`pandas.DataFrame)
+        pandas.DataFrame: clean_data
 
     """
     clean_data = data[data.date >= min_date]
@@ -352,7 +335,7 @@ def validate_plain_data(
     Args:
         raw_data (:obj:`pandas.DataFrame`): raw data (A group)
         split_data (:obj:`pandas.DataFrame`): split data (B group)
-        float_limit (float, optional): maximum deviation for equality test
+        float_limit (float): maximum deviation for equality test
 
     Returns:
         (None): asserts internally
@@ -381,10 +364,10 @@ def validate_split_data(
         raw_data (:obj:`pandas.DataFrame`): raw data (A group)
         split_data (:obj:`pandas.DataFrame`): split data (B group)
         split_obj (:obj:`split_utils.SplitInfo`): split information
-        float_limit (float, optional): maximum deviation for equality test
+        float_limit (float): maximum deviation for equality test
 
-    Returns:
-        (None): asserts internally
+    Raises:
+        AssertionError: asserts expected shapes
 
     """
     for column in split_data.columns.values:
@@ -452,68 +435,12 @@ class TestSplit:
             post_split_data
         )
 
-        pre_raw_data.to_csv('pre_raw_data.csv')
-        pre_split_data.to_csv('pre_split_data.csv')
-
         validate_split_data(
             pre_raw_data,
             pre_split_data,
             split_obj
         )
 
-#    def test_forward_happypath_crest(self):
-#        """test a forward-split: crest"""
-#        pytest.skip('CREST deprecated')
-#        split_obj = split_utils.SplitInfo(DEMO_SPLIT)
-#        raw_crest_data1 = crest_utils.fetch_market_history(
-#            TEST_CONFIG.get('TEST', 'region_id'),
-#            self.test_type_id,
-#            mode=api_utils.SwitchCCPSource.CREST,
-#            config=ROOT_CONFIG
-#        )
-#        raw_crest_data2 = crest_utils.fetch_market_history(
-#            TEST_CONFIG.get('TEST', 'region_id'),
-#            self.test_original_id,
-#            mode=api_utils.SwitchCCPSource.CREST,
-#            config=ROOT_CONFIG
-#        )
-#        split_data = split_utils.fetch_split_history(
-#            TEST_CONFIG.get('TEST', 'region_id'),
-#            DEMO_SPLIT['type_id'],
-#            api_utils.SwitchCCPSource.CREST,
-#            config=ROOT_CONFIG
-#        )
-#        #split_data.to_csv('split_data_crest.csv', index=False)
-#
-#        ## Doctor data for testing ##
-#        min_split_date = split_data.date.min()
-#        raw_crest_data1 = prep_raw_data(
-#            raw_crest_data1.copy(),
-#            min_split_date
-#        )
-#        raw_crest_data2 = prep_raw_data(
-#            raw_crest_data2.copy(),
-#            min_split_date
-#        )
-#
-#        split_date_str = datetime.strftime(split_obj.split_date, '%Y-%m-%dT%H:%M:%S')
-#        pre_split_data = split_data[split_data.date <= split_date_str].reset_index()
-#        pre_raw_data = raw_crest_data2[raw_crest_data2.date <= split_date_str].reset_index()
-#        post_split_data = split_data[split_data.date > split_date_str].reset_index()
-#        post_raw_data = raw_crest_data1[raw_crest_data1.date > split_date_str].reset_index()
-#
-#        ## Validate pre/post Split values ##
-#        validate_plain_data(
-#            post_raw_data,
-#            post_split_data
-#        )
-#
-#        validate_split_data(
-#            pre_raw_data,
-#            pre_split_data,
-#            split_obj
-#        )
-#
     def test_forward_happypath_emd(self):
         """test a forward-split: emd"""
         split_obj = split_utils.SplitInfo(DEMO_SPLIT)
@@ -538,7 +465,6 @@ class TestSplit:
             api_utils.SwitchCCPSource.EMD,
             config=ROOT_CONFIG
         )
-        #split_data.to_csv('split_data_emd.csv', index=False)
 
         ## Doctor data for testing ##
         min_split_date = split_data.date.min()

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -270,10 +270,10 @@ class TestNoSplit:
 
     def test_future_split_emd(self):
         """valdiate with EMD source"""
-        pytest.skip('EMD mode deprecated')
         test_data_emd = split_utils.fetch_split_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             self.test_type_id,
+            fetch_source=api_utils.SwitchCCPSource.EMD,
             data_range=TEST_CONFIG.get('TEST', 'history_count'),
             config=ROOT_CONFIG
         )
@@ -456,59 +456,59 @@ class TestSplit:
             split_obj
         )
 
-    def test_forward_happypath_crest(self):
-        """test a forward-split: crest"""
-        pytest.skip('CREST deprecated')
-        split_obj = split_utils.SplitInfo(DEMO_SPLIT)
-        raw_crest_data1 = crest_utils.fetch_market_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            self.test_type_id,
-            mode=api_utils.SwitchCCPSource.CREST,
-            config=ROOT_CONFIG
-        )
-        raw_crest_data2 = crest_utils.fetch_market_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            self.test_original_id,
-            mode=api_utils.SwitchCCPSource.CREST,
-            config=ROOT_CONFIG
-        )
-        split_data = split_utils.fetch_split_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            DEMO_SPLIT['type_id'],
-            api_utils.SwitchCCPSource.CREST,
-            config=ROOT_CONFIG
-        )
-        #split_data.to_csv('split_data_crest.csv', index=False)
-
-        ## Doctor data for testing ##
-        min_split_date = split_data.date.min()
-        raw_crest_data1 = prep_raw_data(
-            raw_crest_data1.copy(),
-            min_split_date
-        )
-        raw_crest_data2 = prep_raw_data(
-            raw_crest_data2.copy(),
-            min_split_date
-        )
-
-        split_date_str = datetime.strftime(split_obj.split_date, '%Y-%m-%dT%H:%M:%S')
-        pre_split_data = split_data[split_data.date <= split_date_str].reset_index()
-        pre_raw_data = raw_crest_data2[raw_crest_data2.date <= split_date_str].reset_index()
-        post_split_data = split_data[split_data.date > split_date_str].reset_index()
-        post_raw_data = raw_crest_data1[raw_crest_data1.date > split_date_str].reset_index()
-
-        ## Validate pre/post Split values ##
-        validate_plain_data(
-            post_raw_data,
-            post_split_data
-        )
-
-        validate_split_data(
-            pre_raw_data,
-            pre_split_data,
-            split_obj
-        )
-
+#    def test_forward_happypath_crest(self):
+#        """test a forward-split: crest"""
+#        pytest.skip('CREST deprecated')
+#        split_obj = split_utils.SplitInfo(DEMO_SPLIT)
+#        raw_crest_data1 = crest_utils.fetch_market_history(
+#            TEST_CONFIG.get('TEST', 'region_id'),
+#            self.test_type_id,
+#            mode=api_utils.SwitchCCPSource.CREST,
+#            config=ROOT_CONFIG
+#        )
+#        raw_crest_data2 = crest_utils.fetch_market_history(
+#            TEST_CONFIG.get('TEST', 'region_id'),
+#            self.test_original_id,
+#            mode=api_utils.SwitchCCPSource.CREST,
+#            config=ROOT_CONFIG
+#        )
+#        split_data = split_utils.fetch_split_history(
+#            TEST_CONFIG.get('TEST', 'region_id'),
+#            DEMO_SPLIT['type_id'],
+#            api_utils.SwitchCCPSource.CREST,
+#            config=ROOT_CONFIG
+#        )
+#        #split_data.to_csv('split_data_crest.csv', index=False)
+#
+#        ## Doctor data for testing ##
+#        min_split_date = split_data.date.min()
+#        raw_crest_data1 = prep_raw_data(
+#            raw_crest_data1.copy(),
+#            min_split_date
+#        )
+#        raw_crest_data2 = prep_raw_data(
+#            raw_crest_data2.copy(),
+#            min_split_date
+#        )
+#
+#        split_date_str = datetime.strftime(split_obj.split_date, '%Y-%m-%dT%H:%M:%S')
+#        pre_split_data = split_data[split_data.date <= split_date_str].reset_index()
+#        pre_raw_data = raw_crest_data2[raw_crest_data2.date <= split_date_str].reset_index()
+#        post_split_data = split_data[split_data.date > split_date_str].reset_index()
+#        post_raw_data = raw_crest_data1[raw_crest_data1.date > split_date_str].reset_index()
+#
+#        ## Validate pre/post Split values ##
+#        validate_plain_data(
+#            post_raw_data,
+#            post_split_data
+#        )
+#
+#        validate_split_data(
+#            pre_raw_data,
+#            pre_split_data,
+#            split_obj
+#        )
+#
     def test_forward_happypath_emd(self):
         """test a forward-split: crest"""
         split_obj = split_utils.SplitInfo(DEMO_SPLIT)

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -300,7 +300,9 @@ class TestNoSplit:
             data_range=short_days,
             config=ROOT_CONFIG
         )
-        assert test_data_emd.equals(forecast_utils.parse_emd_data(emd_data_raw['result']))
+
+        assert test_data_emd.equals(
+            forecast_utils.parse_emd_data(emd_data_raw['result']))
 
 def days_since_date(date_str):
     """return number of days since date requested

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -25,31 +25,31 @@ DAYS_SINCE_SPLIT = 10
 TEST_DATE = datetime.utcnow() - timedelta(days=DAYS_SINCE_SPLIT)
 FUTURE_DATE = datetime.utcnow() + timedelta(days=DAYS_SINCE_SPLIT)
 DEMO_SPLIT = {
-    "type_id":35,
-    "type_name":"Tritanium",
-    "original_id":34,
-    "new_id":35,
-    "split_date":TEST_DATE.strftime('%Y-%m-%d'),
-    "bool_mult_div":"False",
-    "split_rate": 10
+    'type_id':35,
+    'type_name':'Tritanium',
+    'original_id':34,
+    'new_id':35,
+    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
+    'bool_mult_div':'False',
+    'split_rate': 10
 }
 DEMO_UNSPLIT = {
-    "type_id":34,
-    "type_name":"Pyerite",
-    "original_id":34,
-    "new_id":35,
-    "split_date":FUTURE_DATE.strftime('%Y-%m-%d'),
-    "bool_mult_div":"True",
-    "split_rate": 10
+    'type_id':34,
+    'type_name':'Pyerite',
+    'original_id':34,
+    'new_id':35,
+    'split_date':FUTURE_DATE.strftime('%Y-%m-%d'),
+    'bool_mult_div':'True',
+    'split_rate': 10
 }
 DEMO_NOSPLIT = {
-    "type_id":35,
-    "type_name":"Tritanium",
-    "original_id":35,
-    "new_id":35,
-    "split_date":TEST_DATE.strftime('%Y-%m-%d'),
-    "bool_mult_div":"False",
-    "split_rate": 10
+    'type_id':35,
+    'type_name':'Tritanium',
+    'original_id':35,
+    'new_id':35,
+    'split_date':TEST_DATE.strftime('%Y-%m-%d'),
+    'bool_mult_div':'False',
+    'split_rate': 10
 }
 ROOT_CONFIG = helpers.get_config(
     path.join(ROOT, 'scripts', 'app.cfg')
@@ -244,12 +244,13 @@ class TestNoSplit:
             api_utils.SwitchCCPSource.ESI,
             config=ROOT_CONFIG
         )
-        assert test_data_esi.equals(crest_utils.fetch_market_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            self.test_type_id,
-            mode=api_utils.SwitchCCPSource.ESI,
-            config=ROOT_CONFIG
-        ))
+        assert test_data_esi.equals(
+            crest_utils.fetch_market_history(
+                TEST_CONFIG.get('TEST', 'region_id'),
+                self.test_type_id,
+                config=ROOT_CONFIG
+            )
+        )
 
     def test_future_split_crest(self):
         """validate with CREST source"""
@@ -259,19 +260,20 @@ class TestNoSplit:
             api_utils.SwitchCCPSource.CREST,
             config=ROOT_CONFIG
         )
-        assert test_data_crest.equals(crest_utils.fetch_market_history(
-            TEST_CONFIG.get('TEST', 'region_id'),
-            self.test_type_id,
-            mode=api_utils.SwitchCCPSource.CREST,
-            config=ROOT_CONFIG
-        ))
+        assert test_data_crest.equals(
+            crest_utils.fetch_market_history(
+                TEST_CONFIG.get('TEST', 'region_id'),
+                self.test_type_id,
+                config=ROOT_CONFIG
+            )
+        )
 
     def test_future_split_emd(self):
         """valdiate with EMD source"""
+        pytest.skip('EMD mode deprecated')
         test_data_emd = split_utils.fetch_split_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             self.test_type_id,
-            api_utils.SwitchCCPSource.EMD,
             data_range=TEST_CONFIG.get('TEST', 'history_count'),
             config=ROOT_CONFIG
         )
@@ -289,7 +291,6 @@ class TestNoSplit:
         test_data_emd = split_utils.fetch_split_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             DEMO_SPLIT['type_id'],
-            api_utils.SwitchCCPSource.EMD,
             data_range=short_days,
             config=ROOT_CONFIG
         )
@@ -413,19 +414,16 @@ class TestSplit:
         raw_esi_data1 = crest_utils.fetch_market_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             self.test_type_id,
-            mode=api_utils.SwitchCCPSource.ESI,
             config=ROOT_CONFIG
         )
         raw_esi_data2 = crest_utils.fetch_market_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             self.test_original_id,
-            mode=api_utils.SwitchCCPSource.ESI,
             config=ROOT_CONFIG
         )
         split_data = split_utils.fetch_split_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             DEMO_SPLIT['type_id'],
-            api_utils.SwitchCCPSource.ESI,
             config=ROOT_CONFIG
         )
         #split_data.to_csv('split_data_esi.csv', index=False)
@@ -460,6 +458,7 @@ class TestSplit:
 
     def test_forward_happypath_crest(self):
         """test a forward-split: crest"""
+        pytest.skip('CREST deprecated')
         split_obj = split_utils.SplitInfo(DEMO_SPLIT)
         raw_crest_data1 = crest_utils.fetch_market_history(
             TEST_CONFIG.get('TEST', 'region_id'),

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -388,8 +388,8 @@ def validate_split_data(
 
     """
     for column in split_data.columns.values:
-        print(split_data[column])
-        print(raw_data[column])
+        #print(split_data[column])
+        #print(raw_data[column])
         if column == 'date':
             assert split_data[column].equals(raw_data[column])
         elif column == 'index':
@@ -405,7 +405,6 @@ def validate_split_data(
             )
             assert diff.max() < float_limit
 
-@pytest.mark.incremental
 class TestSplit:
     """test end-to-end behavior on fetch_split_history"""
     test_type_id = DEMO_SPLIT['type_id']
@@ -426,6 +425,7 @@ class TestSplit:
         split_data = split_utils.fetch_split_history(
             TEST_CONFIG.get('TEST', 'region_id'),
             DEMO_SPLIT['type_id'],
+            fetch_source=api_utils.SwitchCCPSource.ESI,
             config=ROOT_CONFIG
         )
         #split_data.to_csv('split_data_esi.csv', index=False)
@@ -451,6 +451,9 @@ class TestSplit:
             post_raw_data,
             post_split_data
         )
+
+        pre_raw_data.to_csv('pre_raw_data.csv')
+        pre_split_data.to_csv('pre_split_data.csv')
 
         validate_split_data(
             pre_raw_data,
@@ -512,7 +515,7 @@ class TestSplit:
 #        )
 #
     def test_forward_happypath_emd(self):
-        """test a forward-split: crest"""
+        """test a forward-split: emd"""
         split_obj = split_utils.SplitInfo(DEMO_SPLIT)
         raw_emd_data = forecast_utils.fetch_market_history_emd(
             TEST_CONFIG.get('TEST', 'region_id'),


### PR DESCRIPTION
* Fixes serious test errors: https://travis-ci.org/EVEprosper/ProsperAPI/builds/389093207
* Upgrades requirements from `static` to `latest` where possible
    * `pystan` has been locked at `2.15.0` due to API incompatibilities in `fbprophet`
    * `fbprophet` has been upgraded to `0.3.post1` from `0.1.post1`
    * Adds back mac compatibility!
* Fully deprecates `CREST` functionality (sunset by CCP)
* Improves logging patterns
    * Fixes multiple-handles problem in endpoint tests
    * Reduces dependency on a global logging variable
* Adds a `fast` test command that skips prophet tests
* Adds `.coveragerc` to stop counting weird global spaces